### PR TITLE
Potential fix for code scanning alert no. 17: Email content injection

### DIFF
--- a/internal/handlers/company_handler.go
+++ b/internal/handlers/company_handler.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/mail"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,7 +17,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
-	"net/mail"
 )
 
 type CompanyHandler struct {


### PR DESCRIPTION
- [x] Move `net/mail` import from third-party group into the standard-library block in `company_handler.go`, consistent with other handlers like `auth_handler.go`