### PR TITLE
Potential fix for code scanning alert no. 16: Email content injection

### DIFF
--- a/internal/services/email_service.go
+++ b/internal/services/email_service.go
@@ -5,8 +5,8 @@ import (
 	"crypto/tls"
 	"fmt"
 	"html/template"
-	"net/smtp"
 	"net/mail"
+	"net/smtp"
 	"strconv"
 	"strings"
 	"time"
@@ -36,6 +36,13 @@ func (s *EmailService) sanitizeEmail(addr string) string {
 	}
 	// Use the parsed address which is normalized and safe for headers
 	return parsed.Address
+}
+
+// sanitizeHeaderValue removes CR and LF characters from a header value to prevent injection.
+func sanitizeHeaderValue(s string) string {
+	s = strings.ReplaceAll(s, "\r", "")
+	s = strings.ReplaceAll(s, "\n", "")
+	return s
 }
 
 func NewEmailService(emailConfig *config.EmailConfig) *EmailService {
@@ -387,6 +394,18 @@ Best regards,
 
 // sendEmail sends an email with optional PDF attachment
 func (s *EmailService) sendEmail(to []string, subject, textBody, htmlBody string, attachment []byte, attachmentName string) error {
+	// Sanitize recipients first to prevent header/envelope injection
+	var safeTo []string
+	for _, addr := range to {
+		if cleaned := s.sanitizeEmail(addr); cleaned != "" {
+			safeTo = append(safeTo, cleaned)
+		}
+	}
+	if len(safeTo) == 0 {
+		return fmt.Errorf("no valid recipients")
+	}
+	to = safeTo
+
 	// Check if SMTP is configured
 	if s.config.SMTPHost == "localhost" && s.config.SMTPUsername == "" {
 		return fmt.Errorf("SMTP not configured - please set email configuration in config.json: smtp_host, smtp_port, smtp_username, smtp_password")
@@ -483,9 +502,9 @@ func (s *EmailService) createMIMEMessage(to []string, subject, textBody, htmlBod
 		}
 	}
 	// Headers
-	message.WriteString(fmt.Sprintf("From: %s <%s>\r\n", s.config.FromName, s.config.FromEmail))
+	message.WriteString(fmt.Sprintf("From: %s <%s>\r\n", sanitizeHeaderValue(s.config.FromName), s.config.FromEmail))
 	message.WriteString(fmt.Sprintf("To: %s\r\n", strings.Join(safeTo, ", ")))
-	message.WriteString(fmt.Sprintf("Subject: %s\r\n", subject))
+	message.WriteString(fmt.Sprintf("Subject: %s\r\n", sanitizeHeaderValue(subject)))
 	message.WriteString("MIME-Version: 1.0\r\n")
 
 	if attachment != nil {


### PR DESCRIPTION
Potential fix for <a href="https://github.com/SJ-tech-Sweden/rentalcore/security/code-scanning/16">https://github.com/SJ-tech-Sweden/rentalcore/security/code-scanning/16</a>

In general, to fix email content injection you must ensure that any untrusted data used in email headers or body is either validated against a safe pattern (e.g., a strict email address regex) or sanitized to remove dangerous characters (notably `\r` and `\n` in headers). For header fields like `To:` and `Subject:`, it is usually better to validate and reject invalid input rather than silently modify it.

The fix sanitizes and validates recipient addresses before they are used in both the SMTP envelope and MIME headers. A `sanitizeEmail` helper on `EmailService` trims whitespace, rejects any address containing CR (`\r`) or LF (`\n`), and uses Go's standard library email address parsing (`net/mail`) to ensure structural validity. Recipient sanitization is applied at the top of `sendEmail` so that both `client.Rcpt()`/`smtp.SendMail()` (SMTP envelope) and `createMIMEMessage` (MIME `To:` header) use only validated addresses. An error is returned if no valid recipients remain after sanitization. A `sanitizeHeaderValue` helper strips CR/LF from the `FromName` and `Subject` header fields to prevent injection through those values as well.

To implement this, the changes: (1) import `"net/mail"` (alphabetically sorted before `"net/smtp"`) in `internal/services/email_service.go`; (2) add the `sanitizeEmail` method for recipient validation; (3) add the `sanitizeHeaderValue` helper for other header fields; (4) sanitize the `to` slice at the start of `sendEmail` and return an error if all recipients are invalid; and (5) apply `sanitizeHeaderValue` to `FromName` and `Subject` in `createMIMEMessage`.

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._