### PR TITLE
Potential fix for code scanning alert no. 27: Incorrect conversion between integer types

### DIFF
--- a/internal/repository/cable_repository.go
+++ b/internal/repository/cable_repository.go
@@ -253,7 +253,7 @@ func applyCableFilters(query *gorm.DB, params *models.FilterParams) *gorm.DB {
 	}
 
 	if params.CableTypeID != nil {
-		query = query.Where("typ = ?", int(*params.CableTypeID))
+		query = query.Where("typ = ?", *params.CableTypeID)
 	}
 	if params.MinLength != nil {
 		query = query.Where("length >= ?", *params.MinLength)


### PR DESCRIPTION
Potential fix for [https://github.com/SJ-tech-Sweden/rentalcore/security/code-scanning/27](https://github.com/SJ-tech-Sweden/rentalcore/security/code-scanning/27)

General approach: Avoid converting a `uint` (originating from `ParseUint` with bitSize 32) to a potentially smaller signed `int` without bounds checks. Either (a) remove the conversion and pass the `uint` directly to GORM, or (b) add explicit upper-bound checks and reject out-of-range values. To keep behavior unchanged and minimal, removing the unnecessary cast is best.

Concretely, in `internal/repository/cable_repository.go` inside `applyCableFilters`, the only flagged location is:

```go
if params.CableTypeID != nil {
    query = query.Where("typ = ?", int(*params.CableTypeID))
}
```

We can simply change this to:

```go
if params.CableTypeID != nil {
    query = query.Where("typ = ?", *params.CableTypeID)
}
```

This avoids the problematic conversion entirely. GORM will bind the `uint` value directly as the query parameter, which is compatible with how `params.Connector1ID` and `params.Connector2ID` were originally obtained (also from `ParseUint`). We do not need any new imports or helper functions; the change is localized to this single line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
