### PR TITLE
fix ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
     steps:
       - name: Check out code


### PR DESCRIPTION
- [x] Remove duplicate `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` from job-level env (already set at workflow level)