### PR TITLE
Fix app_settings schema migration, scope-aware queries, atomic upserts, local date formatting, and currency XSS

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -478,10 +478,10 @@ func main() {
 			return 0
 		},
 		"formatDateNew": func(t time.Time) string {
-			return t.Format("Jan 2, 2006")
+			return t.Format("2006-01-02")
 		},
 		"formatDateTime": func(t time.Time) string {
-			return t.Format("Jan 2, 2006 at 3:04 PM")
+			return t.Format("2006-01-02 15:04")
 		},
 		"substrNew": func(s string, start, length int) string {
 			if start >= len(s) {

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -318,8 +318,8 @@ func (Manufacturer) TableName() string {
 // Both applications read/write the same app_settings table.
 type AppSetting struct {
 	ID        int       `gorm:"primaryKey;autoIncrement;column:id" json:"id"`
-	Scope     string    `gorm:"column:scope;type:varchar(50);default:global" json:"scope"`
-	Key       string    `gorm:"column:key;type:varchar(128)" json:"key"`
+	Scope     string    `gorm:"column:scope;type:varchar(50);default:global;uniqueIndex:idx_app_settings_scope_key" json:"scope"`
+	Key       string    `gorm:"column:key;type:varchar(128);uniqueIndex:idx_app_settings_scope_key" json:"key"`
 	Value     string    `gorm:"column:value;type:text" json:"value"`
 	UpdatedAt time.Time `gorm:"column:updated_at;autoUpdateTime" json:"updatedAt"`
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -317,7 +317,9 @@ func (Manufacturer) TableName() string {
 // AppSetting stores application-wide key-value settings shared with WarehouseCore.
 // Both applications read/write the same app_settings table.
 type AppSetting struct {
-	Key       string    `gorm:"primaryKey;column:key;type:varchar(128)" json:"key"`
+	ID        int       `gorm:"primaryKey;autoIncrement;column:id" json:"id"`
+	Scope     string    `gorm:"column:scope;type:varchar(50);default:global" json:"scope"`
+	Key       string    `gorm:"column:key;type:varchar(128)" json:"key"`
 	Value     string    `gorm:"column:value;type:text" json:"value"`
 	UpdatedAt time.Time `gorm:"column:updated_at;autoUpdateTime" json:"updatedAt"`
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -318,8 +318,8 @@ func (Manufacturer) TableName() string {
 // Both applications read/write the same app_settings table.
 type AppSetting struct {
 	ID        int       `gorm:"primaryKey;autoIncrement;column:id" json:"id"`
-	Scope     string    `gorm:"column:scope;type:varchar(50);default:global;uniqueIndex:idx_app_settings_scope_key" json:"scope"`
-	Key       string    `gorm:"column:key;type:varchar(128);uniqueIndex:idx_app_settings_scope_key" json:"key"`
+	Scope     string    `gorm:"column:scope;type:varchar(50);not null;default:global;uniqueIndex:idx_app_settings_scope_key" json:"scope"`
+	Key       string    `gorm:"column:key;type:varchar(128);not null;uniqueIndex:idx_app_settings_scope_key" json:"key"`
 	Value     string    `gorm:"column:value;type:text" json:"value"`
 	UpdatedAt time.Time `gorm:"column:updated_at;autoUpdateTime" json:"updatedAt"`
 }

--- a/internal/services/settings_service.go
+++ b/internal/services/settings_service.go
@@ -57,17 +57,24 @@ func (s *SettingsService) GetCurrencySymbol() string {
 		return s.cachedCurrency
 	}
 
-	symbol := s.readCurrencyFromDB()
-
-	s.cachedCurrency = symbol
-	s.cacheValid = true
-	s.cacheExpiry = time.Now().Add(currencyCacheTTL)
+	symbol, cacheable := s.readCurrencyFromDB()
+	if cacheable {
+		s.cachedCurrency = symbol
+		s.cacheValid = true
+		s.cacheExpiry = time.Now().Add(currencyCacheTTL)
+	} else if s.cacheValid {
+		// Preserve stale cached value on transient DB errors.
+		return s.cachedCurrency
+	}
 	return symbol
 }
 
 // readCurrencyFromDB tries scope='global' then scope='warehousecore', parsing
 // the shared JSON format {"symbol":"..."} used by both services.
-func (s *SettingsService) readCurrencyFromDB() string {
+// Returns (symbol, cacheable) where cacheable is false on transient DB errors
+// (in which case the caller should retain any previously cached value).
+func (s *SettingsService) readCurrencyFromDB() (string, bool) {
+	cacheable := true
 	for _, scope := range []string{"global", "warehousecore"} {
 		var setting models.AppSetting
 		err := s.db.Where("scope = ? AND key = ?", scope, AppCurrencyKey).First(&setting).Error
@@ -76,49 +83,54 @@ func (s *SettingsService) readCurrencyFromDB() string {
 		}
 		if err != nil {
 			log.Printf("SettingsService: failed to read %q (scope=%s): %v", AppCurrencyKey, scope, err)
+			cacheable = false
 			continue
 		}
 		// Value is stored as JSON {"symbol":"..."} in both scopes.
 		var m map[string]interface{}
 		if json.Unmarshal([]byte(setting.Value), &m) == nil {
 			if sym, ok := m["symbol"].(string); ok && sym != "" {
-				return sym
+				return sym, true
 			}
 		}
 		// Fall back to treating the raw value as the symbol (plain-text legacy rows).
 		if setting.Value != "" {
-			return setting.Value
+			return setting.Value, true
 		}
 	}
-	return defaultCurrencySymbol
+	return defaultCurrencySymbol, cacheable
 }
 
 // UpdateCurrencySymbol persists a new currency symbol and invalidates the cache.
 // The value is written to scope='global' in the JSON format {"symbol":"..."} so
 // that WarehouseCore can also read it via the same shared table.
 func (s *SettingsService) UpdateCurrencySymbol(symbol string) error {
-	jsonValue := `{"symbol":"` + symbol + `"}`
+	jsonBytes, err := json.Marshal(map[string]string{"symbol": symbol})
+	if err != nil {
+		return fmt.Errorf("failed to encode currency symbol: %w", err)
+	}
+	jsonValue := string(jsonBytes)
 
-	var setting models.AppSetting
-	err := s.db.Where("scope = ? AND key = ?", "global", AppCurrencyKey).First(&setting).Error
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		setting = models.AppSetting{
-			Scope: "global",
-			Key:   AppCurrencyKey,
-			Value: jsonValue,
+	err = s.db.Transaction(func(tx *gorm.DB) error {
+		var setting models.AppSetting
+		err := tx.Where("scope = ? AND key = ?", "global", AppCurrencyKey).First(&setting).Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			setting = models.AppSetting{
+				Scope: "global",
+				Key:   AppCurrencyKey,
+				Value: jsonValue,
+			}
+			return tx.Create(&setting).Error
+		} else if err != nil {
+			return fmt.Errorf("failed to look up currency symbol: %w", err)
 		}
-		if err := s.db.Create(&setting).Error; err != nil {
-			return fmt.Errorf("failed to save currency symbol: %w", err)
-		}
-	} else if err != nil {
-		return fmt.Errorf("failed to look up currency symbol: %w", err)
-	} else {
-		if err := s.db.Model(&setting).Updates(map[string]interface{}{
+		return tx.Model(&setting).Updates(map[string]interface{}{
 			"value":      jsonValue,
 			"updated_at": time.Now(),
-		}).Error; err != nil {
-			return fmt.Errorf("failed to save currency symbol: %w", err)
-		}
+		}).Error
+	})
+	if err != nil {
+		return fmt.Errorf("failed to save currency symbol: %w", err)
 	}
 
 	s.mu.Lock()

--- a/internal/services/settings_service.go
+++ b/internal/services/settings_service.go
@@ -91,12 +91,12 @@ func (s *SettingsService) readCurrencyFromDB() (string, bool) {
 		var m map[string]interface{}
 		if json.Unmarshal([]byte(setting.Value), &m) == nil {
 			if sym, ok := m["symbol"].(string); ok && sym != "" {
-				return sym, true
+				return sym, cacheable
 			}
 		}
 		// Fall back to treating the raw value as the symbol (plain-text legacy rows).
 		if setting.Value != "" {
-			return setting.Value, true
+			return setting.Value, cacheable
 		}
 	}
 	return defaultCurrencySymbol, cacheable

--- a/internal/services/settings_service.go
+++ b/internal/services/settings_service.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 const (
@@ -104,6 +105,7 @@ func (s *SettingsService) readCurrencyFromDB() (string, bool) {
 // UpdateCurrencySymbol persists a new currency symbol and invalidates the cache.
 // The value is written to scope='global' in the JSON format {"symbol":"..."} so
 // that WarehouseCore can also read it via the same shared table.
+// Uses a single atomic upsert to avoid races under concurrent writes.
 func (s *SettingsService) UpdateCurrencySymbol(symbol string) error {
 	jsonBytes, err := json.Marshal(map[string]string{"symbol": symbol})
 	if err != nil {
@@ -111,25 +113,15 @@ func (s *SettingsService) UpdateCurrencySymbol(symbol string) error {
 	}
 	jsonValue := string(jsonBytes)
 
-	err = s.db.Transaction(func(tx *gorm.DB) error {
-		var setting models.AppSetting
-		err := tx.Where("scope = ? AND key = ?", "global", AppCurrencyKey).First(&setting).Error
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			setting = models.AppSetting{
-				Scope: "global",
-				Key:   AppCurrencyKey,
-				Value: jsonValue,
-			}
-			return tx.Create(&setting).Error
-		} else if err != nil {
-			return fmt.Errorf("failed to look up currency symbol: %w", err)
-		}
-		return tx.Model(&setting).Updates(map[string]interface{}{
-			"value":      jsonValue,
-			"updated_at": time.Now(),
-		}).Error
-	})
-	if err != nil {
+	setting := models.AppSetting{
+		Scope: "global",
+		Key:   AppCurrencyKey,
+		Value: jsonValue,
+	}
+	if err := s.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "scope"}, {Name: "key"}},
+		DoUpdates: clause.Assignments(map[string]interface{}{"value": jsonValue, "updated_at": time.Now()}),
+	}).Create(&setting).Error; err != nil {
 		return fmt.Errorf("failed to save currency symbol: %w", err)
 	}
 

--- a/internal/services/settings_service.go
+++ b/internal/services/settings_service.go
@@ -1,14 +1,15 @@
 package services
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"go-barcode-webapp/internal/models"
 	"log"
 	"sync"
 	"time"
 
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 )
 
 const (
@@ -56,43 +57,68 @@ func (s *SettingsService) GetCurrencySymbol() string {
 		return s.cachedCurrency
 	}
 
-	var setting models.AppSetting
-	err := s.db.Where("key = ?", AppCurrencyKey).First(&setting).Error
-	switch {
-	case err == nil:
-		s.cachedCurrency = setting.Value
-		s.cacheValid = true
-		s.cacheExpiry = time.Now().Add(currencyCacheTTL)
-	case errors.Is(err, gorm.ErrRecordNotFound):
-		// No row yet – use and cache the default.
-		s.cachedCurrency = defaultCurrencySymbol
-		s.cacheValid = true
-		s.cacheExpiry = time.Now().Add(currencyCacheTTL)
-	default:
-		// Transient DB error – do not overwrite a valid cached value.
-		log.Printf("SettingsService: failed to read %q: %v", AppCurrencyKey, err)
-		if s.cacheValid {
-			return s.cachedCurrency
+	symbol := s.readCurrencyFromDB()
+
+	s.cachedCurrency = symbol
+	s.cacheValid = true
+	s.cacheExpiry = time.Now().Add(currencyCacheTTL)
+	return symbol
+}
+
+// readCurrencyFromDB tries scope='global' then scope='warehousecore', parsing
+// the shared JSON format {"symbol":"..."} used by both services.
+func (s *SettingsService) readCurrencyFromDB() string {
+	for _, scope := range []string{"global", "warehousecore"} {
+		var setting models.AppSetting
+		err := s.db.Where("scope = ? AND key = ?", scope, AppCurrencyKey).First(&setting).Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			continue
 		}
-		return defaultCurrencySymbol
+		if err != nil {
+			log.Printf("SettingsService: failed to read %q (scope=%s): %v", AppCurrencyKey, scope, err)
+			continue
+		}
+		// Value is stored as JSON {"symbol":"..."} in both scopes.
+		var m map[string]interface{}
+		if json.Unmarshal([]byte(setting.Value), &m) == nil {
+			if sym, ok := m["symbol"].(string); ok && sym != "" {
+				return sym
+			}
+		}
+		// Fall back to treating the raw value as the symbol (plain-text legacy rows).
+		if setting.Value != "" {
+			return setting.Value
+		}
 	}
-	return s.cachedCurrency
+	return defaultCurrencySymbol
 }
 
 // UpdateCurrencySymbol persists a new currency symbol and invalidates the cache.
+// The value is written to scope='global' in the JSON format {"symbol":"..."} so
+// that WarehouseCore can also read it via the same shared table.
 func (s *SettingsService) UpdateCurrencySymbol(symbol string) error {
-	setting := models.AppSetting{
-		Key:   AppCurrencyKey,
-		Value: symbol,
-	}
-	if err := s.db.Clauses(clause.OnConflict{
-		Columns: []clause.Column{{Name: "key"}},
-		DoUpdates: clause.Assignments(map[string]interface{}{
-			"value":      symbol,
+	jsonValue := `{"symbol":"` + symbol + `"}`
+
+	var setting models.AppSetting
+	err := s.db.Where("scope = ? AND key = ?", "global", AppCurrencyKey).First(&setting).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		setting = models.AppSetting{
+			Scope: "global",
+			Key:   AppCurrencyKey,
+			Value: jsonValue,
+		}
+		if err := s.db.Create(&setting).Error; err != nil {
+			return fmt.Errorf("failed to save currency symbol: %w", err)
+		}
+	} else if err != nil {
+		return fmt.Errorf("failed to look up currency symbol: %w", err)
+	} else {
+		if err := s.db.Model(&setting).Updates(map[string]interface{}{
+			"value":      jsonValue,
 			"updated_at": time.Now(),
-		}),
-	}).Create(&setting).Error; err != nil {
-		return err
+		}).Error; err != nil {
+			return fmt.Errorf("failed to save currency symbol: %w", err)
+		}
 	}
 
 	s.mu.Lock()

--- a/internal/services/settings_service_test.go
+++ b/internal/services/settings_service_test.go
@@ -214,8 +214,10 @@ func TestUpdateCurrencySymbol_Upsert_Update(t *testing.T) {
 	if err := db.Where("key = ?", AppCurrencyKey).First(&row).Error; err != nil {
 		t.Fatalf("DB read after upsert: %v", err)
 	}
-	if row.Value != "CHF" {
-		t.Errorf("DB row value = %q, want %q", row.Value, "CHF")
+	// Value is stored as JSON {"symbol":"..."} by UpdateCurrencySymbol.
+	wantValue := `{"symbol":"CHF"}`
+	if row.Value != wantValue {
+		t.Errorf("DB row value = %q, want %q", row.Value, wantValue)
 	}
 
 	// Confirm only one row exists.

--- a/internal/services/settings_service_test.go
+++ b/internal/services/settings_service_test.go
@@ -290,3 +290,69 @@ func TestGetCurrencySymbol_TransientError_NoPreviousCache(t *testing.T) {
 		t.Errorf("GetCurrencySymbol() with closed DB and no cache = %q, want default %q", got, defaultCurrencySymbol)
 	}
 }
+
+// TestGetCurrencySymbol_JSONEncodedValue verifies that GetCurrencySymbol correctly
+// parses the shared JSON format {"symbol":"..."} used by both RentalCore and WarehouseCore.
+func TestGetCurrencySymbol_JSONEncodedValue(t *testing.T) {
+	db := newTestDB(t)
+	db.Create(&models.AppSetting{Scope: "global", Key: AppCurrencyKey, Value: `{"symbol":"kr"}`})
+
+	s := NewSettingsService(db)
+	got := s.GetCurrencySymbol()
+	if got != "kr" {
+		t.Errorf("GetCurrencySymbol() with JSON value = %q, want %q", got, "kr")
+	}
+	if !s.cacheValid {
+		t.Error("expected cacheValid=true after successful JSON parse")
+	}
+}
+
+// TestGetCurrencySymbol_WarehousecoreFallback verifies that when no 'global' row exists
+// the service falls back to the 'warehousecore' scope and parses its JSON value.
+func TestGetCurrencySymbol_WarehousecoreFallback(t *testing.T) {
+	db := newTestDB(t)
+	// Only insert a 'warehousecore' row — no 'global' row.
+	db.Create(&models.AppSetting{Scope: "warehousecore", Key: AppCurrencyKey, Value: `{"symbol":"SEK"}`})
+
+	s := NewSettingsService(db)
+	got := s.GetCurrencySymbol()
+	if got != "SEK" {
+		t.Errorf("GetCurrencySymbol() warehousecore fallback = %q, want %q", got, "SEK")
+	}
+	if !s.cacheValid {
+		t.Error("expected cacheValid=true after successful warehousecore fallback read")
+	}
+}
+
+// TestGetCurrencySymbol_GlobalTakesPrecedenceOverWarehousecore verifies that the
+// 'global' scope row takes precedence when both scopes are present.
+func TestGetCurrencySymbol_GlobalTakesPrecedenceOverWarehousecore(t *testing.T) {
+	db := newTestDB(t)
+	db.Create(&models.AppSetting{Scope: "global", Key: AppCurrencyKey, Value: `{"symbol":"€"}`})
+	db.Create(&models.AppSetting{Scope: "warehousecore", Key: AppCurrencyKey, Value: `{"symbol":"kr"}`})
+
+	s := NewSettingsService(db)
+	got := s.GetCurrencySymbol()
+	if got != "€" {
+		t.Errorf("GetCurrencySymbol() = %q, want global scope %q to take precedence", got, "€")
+	}
+}
+
+// TestGetCurrencySymbol_JSONAfterCacheExpiry verifies that an expired cache entry is
+// refreshed from the DB and the JSON value is correctly parsed.
+func TestGetCurrencySymbol_JSONAfterCacheExpiry(t *testing.T) {
+	db := newTestDB(t)
+	db.Create(&models.AppSetting{Scope: "global", Key: AppCurrencyKey, Value: `{"symbol":"CHF"}`})
+
+	s := &SettingsService{
+		db:             db,
+		cachedCurrency: "£",
+		cacheValid:     true,
+		cacheExpiry:    time.Now().Add(-1 * time.Second), // expired
+	}
+
+	got := s.GetCurrencySymbol()
+	if got != "CHF" {
+		t.Errorf("GetCurrencySymbol() after cache expiry = %q, want DB JSON value %q", got, "CHF")
+	}
+}

--- a/internal/services/settings_service_test.go
+++ b/internal/services/settings_service_test.go
@@ -123,7 +123,7 @@ func TestGetCurrencySymbol_NoCacheEntry(t *testing.T) {
 // from the DB when the cache is cold and returns the stored symbol.
 func TestGetCurrencySymbol_DBRecord(t *testing.T) {
 	db := newTestDB(t)
-	db.Create(&models.AppSetting{Key: AppCurrencyKey, Value: "$"})
+	db.Create(&models.AppSetting{Scope: "global", Key: AppCurrencyKey, Value: "$"})
 
 	s := NewSettingsService(db)
 	got := s.GetCurrencySymbol()
@@ -161,7 +161,7 @@ func TestGetCurrencySymbol_TransientError(t *testing.T) {
 	db := newTestDB(t)
 
 	// Seed a value and warm the cache.
-	db.Create(&models.AppSetting{Key: AppCurrencyKey, Value: "£"})
+	db.Create(&models.AppSetting{Scope: "global", Key: AppCurrencyKey, Value: "£"})
 	s := NewSettingsService(db)
 	_ = s.GetCurrencySymbol() // warm the cache
 
@@ -203,7 +203,7 @@ func TestUpdateCurrencySymbol_Upsert_Insert(t *testing.T) {
 // updates an existing row without creating duplicates.
 func TestUpdateCurrencySymbol_Upsert_Update(t *testing.T) {
 	db := newTestDB(t)
-	db.Create(&models.AppSetting{Key: AppCurrencyKey, Value: "€"})
+	db.Create(&models.AppSetting{Scope: "global", Key: AppCurrencyKey, Value: "€"})
 	s := NewSettingsService(db)
 
 	if err := s.UpdateCurrencySymbol("CHF"); err != nil {
@@ -211,7 +211,7 @@ func TestUpdateCurrencySymbol_Upsert_Update(t *testing.T) {
 	}
 
 	var row models.AppSetting
-	if err := db.Where("key = ?", AppCurrencyKey).First(&row).Error; err != nil {
+	if err := db.Where("scope = ? AND key = ?", "global", AppCurrencyKey).First(&row).Error; err != nil {
 		t.Fatalf("DB read after upsert: %v", err)
 	}
 	// Value is stored as JSON {"symbol":"..."} by UpdateCurrencySymbol.
@@ -222,7 +222,7 @@ func TestUpdateCurrencySymbol_Upsert_Update(t *testing.T) {
 
 	// Confirm only one row exists.
 	var count int64
-	db.Model(&models.AppSetting{}).Where("key = ?", AppCurrencyKey).Count(&count)
+	db.Model(&models.AppSetting{}).Where("scope = ? AND key = ?", "global", AppCurrencyKey).Count(&count)
 	if count != 1 {
 		t.Errorf("row count = %d, want 1 (no duplicates)", count)
 	}
@@ -256,7 +256,7 @@ func TestUpdateCurrencySymbol_CacheRefresh(t *testing.T) {
 // refreshed from the DB when GetCurrencySymbol is called again.
 func TestGetCurrencySymbol_CacheRefreshedAfterExpiry(t *testing.T) {
 	db := newTestDB(t)
-	db.Create(&models.AppSetting{Key: AppCurrencyKey, Value: "zł"})
+	db.Create(&models.AppSetting{Scope: "global", Key: AppCurrencyKey, Value: "zł"})
 
 	// Create service and pre-populate with an expired cache entry for a different symbol.
 	s := &SettingsService{

--- a/internal/services/twenty_service.go
+++ b/internal/services/twenty_service.go
@@ -126,16 +126,16 @@ func (s *TwentyService) SaveConfig(cfg TwentyConfig) error {
 		currencyCode = "EUR"
 	}
 	rows := []models.AppSetting{
-		{Key: TwentyEnabledKey, Value: enabledVal},
-		{Key: TwentyAPIURLKey, Value: strings.TrimRight(cfg.APIURL, "/")},
-		{Key: TwentyAPIKeyKey, Value: cfg.APIKey},
-		{Key: TwentyWebhookSecretKey, Value: cfg.WebhookSecret},
-		{Key: TwentyCurrencyCodeKey, Value: currencyCode},
+		{Scope: "global", Key: TwentyEnabledKey, Value: enabledVal},
+		{Scope: "global", Key: TwentyAPIURLKey, Value: strings.TrimRight(cfg.APIURL, "/")},
+		{Scope: "global", Key: TwentyAPIKeyKey, Value: cfg.APIKey},
+		{Scope: "global", Key: TwentyWebhookSecretKey, Value: cfg.WebhookSecret},
+		{Scope: "global", Key: TwentyCurrencyCodeKey, Value: currencyCode},
 	}
 	if err := s.db.Transaction(func(tx *gorm.DB) error {
 		for _, row := range rows {
 			if err := tx.Clauses(clause.OnConflict{
-				Columns:   []clause.Column{{Name: "key"}},
+				Columns:   []clause.Column{{Name: "scope"}, {Name: "key"}},
 				DoUpdates: clause.Assignments(map[string]interface{}{"value": row.Value, "updated_at": time.Now()}),
 			}).Create(&row).Error; err != nil {
 				return err

--- a/internal/services/twenty_service.go
+++ b/internal/services/twenty_service.go
@@ -89,7 +89,7 @@ type TwentyConfig struct {
 func (s *TwentyService) GetConfig() TwentyConfig {
 	keys := []string{TwentyEnabledKey, TwentyAPIURLKey, TwentyAPIKeyKey, TwentyWebhookSecretKey, TwentyCurrencyCodeKey}
 	var settings []models.AppSetting
-	if result := s.db.Where("key IN ?", keys).Find(&settings); result.Error != nil {
+	if result := s.db.Where("scope = ? AND key IN ?", "global", keys).Find(&settings); result.Error != nil {
 		log.Printf("TwentyService: failed to load configuration from app_settings: %v", result.Error)
 	}
 
@@ -340,7 +340,7 @@ func (s *TwentyService) reverseCustomerIDLookup(twentyID, objectType string) (ui
 	prefix := "twenty." + objectType + "."
 	var setting models.AppSetting
 	result := s.db.
-		Where("key LIKE ? AND value = ?", prefix+"%", twentyID).
+		Where("scope = ? AND key LIKE ? AND value = ?", "global", prefix+"%", twentyID).
 		Limit(1).
 		Find(&setting)
 	if result.Error != nil {
@@ -498,7 +498,7 @@ func (s *TwentyService) execGQL(cfg TwentyConfig, query string, variables map[st
 // It returns ("", nil) when no mapping exists yet, and ("", err) on unexpected DB errors.
 func (s *TwentyService) storedID(settingsKey string) (string, error) {
 	var setting models.AppSetting
-	if err := s.db.Where("key = ?", settingsKey).First(&setting).Error; err != nil {
+	if err := s.db.Where("scope = ? AND key = ?", "global", settingsKey).First(&setting).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return "", nil
 		}
@@ -509,9 +509,9 @@ func (s *TwentyService) storedID(settingsKey string) (string, error) {
 
 // storeID persists a Twenty object ID mapping.
 func (s *TwentyService) storeID(settingsKey, twentyID string) {
-	row := models.AppSetting{Key: settingsKey, Value: twentyID}
+	row := models.AppSetting{Scope: "global", Key: settingsKey, Value: twentyID}
 	if err := s.db.Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "key"}},
+		Columns:   []clause.Column{{Name: "scope"}, {Name: "key"}},
 		DoUpdates: clause.Assignments(map[string]interface{}{"value": twentyID, "updated_at": time.Now()}),
 	}).Create(&row).Error; err != nil {
 		log.Printf("TwentyService: failed to store ID mapping %q: %v", settingsKey, err)

--- a/internal/services/twenty_service_test.go
+++ b/internal/services/twenty_service_test.go
@@ -93,7 +93,7 @@ func TestTwentyService_SaveConfig_Upsert(t *testing.T) {
 	}
 
 	var count int64
-	db.Model(&models.AppSetting{}).Where("key = ?", TwentyEnabledKey).Count(&count)
+	db.Model(&models.AppSetting{}).Where("scope = ? AND key = ?", "global", TwentyEnabledKey).Count(&count)
 	if count != 1 {
 		t.Errorf("expected 1 row for %q, got %d", TwentyEnabledKey, count)
 	}
@@ -119,10 +119,10 @@ func TestTwentyService_SaveConfig_TrailingSlash(t *testing.T) {
 // helperEnableWebhook enables the Twenty integration and sets a webhook secret.
 func helperEnableWebhook(t *testing.T, db *gorm.DB, secret string) {
 	t.Helper()
-	db.Create(&models.AppSetting{Key: TwentyEnabledKey, Value: "true"})
-	db.Create(&models.AppSetting{Key: TwentyAPIURLKey, Value: "https://twenty.example.com"})
-	db.Create(&models.AppSetting{Key: TwentyAPIKeyKey, Value: "test-key"})
-	db.Create(&models.AppSetting{Key: TwentyWebhookSecretKey, Value: secret})
+	db.Create(&models.AppSetting{Scope: "global", Key: TwentyEnabledKey, Value: "true"})
+	db.Create(&models.AppSetting{Scope: "global", Key: TwentyAPIURLKey, Value: "https://twenty.example.com"})
+	db.Create(&models.AppSetting{Scope: "global", Key: TwentyAPIKeyKey, Value: "test-key"})
+	db.Create(&models.AppSetting{Scope: "global", Key: TwentyWebhookSecretKey, Value: secret})
 }
 
 func TestTwentyService_ApplyInboundWebhook_InvalidToken(t *testing.T) {
@@ -151,9 +151,9 @@ func TestTwentyService_ApplyInboundWebhook_NoSecretConfigured(t *testing.T) {
 	db := newTestDB(t)
 	svc := NewTwentyService(db)
 	// Enable without a webhook secret.
-	db.Create(&models.AppSetting{Key: TwentyEnabledKey, Value: "true"})
-	db.Create(&models.AppSetting{Key: TwentyAPIURLKey, Value: "https://twenty.example.com"})
-	db.Create(&models.AppSetting{Key: TwentyAPIKeyKey, Value: "test-key"})
+	db.Create(&models.AppSetting{Scope: "global", Key: TwentyEnabledKey, Value: "true"})
+	db.Create(&models.AppSetting{Scope: "global", Key: TwentyAPIURLKey, Value: "https://twenty.example.com"})
+	db.Create(&models.AppSetting{Scope: "global", Key: TwentyAPIKeyKey, Value: "test-key"})
 
 	payload := []byte(`{"type":"company.updated","record":{"id":"abc"}}`)
 	err := svc.ApplyInboundWebhook(payload, "")
@@ -186,7 +186,7 @@ func TestTwentyService_ApplyInboundWebhook_UpdatesCompany(t *testing.T) {
 
 	twentyID := "twenty-company-001"
 	mappingKey := fmt.Sprintf("twenty.company.%d", customer.CustomerID)
-	db.Create(&models.AppSetting{Key: mappingKey, Value: twentyID})
+	db.Create(&models.AppSetting{Scope: "global", Key: mappingKey, Value: twentyID})
 
 	addr, _ := json.Marshal(map[string]string{
 		"addressStreet1": "New St 1",
@@ -231,7 +231,7 @@ func TestTwentyService_ApplyInboundWebhook_EmptyFieldsNotOverwritten(t *testing.
 
 	twentyID := "twenty-company-002"
 	mappingKey := fmt.Sprintf("twenty.company.%d", customer.CustomerID)
-	db.Create(&models.AppSetting{Key: mappingKey, Value: twentyID})
+	db.Create(&models.AppSetting{Scope: "global", Key: mappingKey, Value: twentyID})
 
 	// Empty address fields must NOT overwrite existing customer data.
 	addr, _ := json.Marshal(map[string]string{
@@ -276,7 +276,7 @@ func TestTwentyService_ApplyInboundWebhook_UpdatesPerson(t *testing.T) {
 
 	twentyID := "twenty-person-001"
 	mappingKey := fmt.Sprintf("twenty.person.%d", customer.CustomerID)
-	db.Create(&models.AppSetting{Key: mappingKey, Value: twentyID})
+	db.Create(&models.AppSetting{Scope: "global", Key: mappingKey, Value: twentyID})
 
 	emailsJSON, _ := json.Marshal(map[string]string{"primaryEmail": "alice@example.com"})
 	phonesJSON, _ := json.Marshal(map[string]string{"primaryPhoneNumber": "+46701234567"})
@@ -360,7 +360,7 @@ func TestReverseCustomerIDLookup(t *testing.T) {
 	db := newTestDB(t)
 	svc := NewTwentyService(db)
 
-	db.Create(&models.AppSetting{Key: "twenty.company.42", Value: "twenty-abc"})
+	db.Create(&models.AppSetting{Scope: "global", Key: "twenty.company.42", Value: "twenty-abc"})
 
 	id, err := svc.reverseCustomerIDLookup("twenty-abc", "company")
 	if err != nil {

--- a/migrations/040_update_app_settings_schema.down.sql
+++ b/migrations/040_update_app_settings_schema.down.sql
@@ -1,0 +1,6 @@
+-- Rollback: revert app_settings schema changes
+ALTER TABLE app_settings DROP CONSTRAINT IF EXISTS idx_app_settings_scope_key;
+ALTER TABLE app_settings DROP CONSTRAINT IF EXISTS app_settings_pkey;
+ALTER TABLE app_settings ADD PRIMARY KEY (key);
+ALTER TABLE app_settings DROP COLUMN IF EXISTS scope;
+ALTER TABLE app_settings DROP COLUMN IF EXISTS id;

--- a/migrations/040_update_app_settings_schema.down.sql
+++ b/migrations/040_update_app_settings_schema.down.sql
@@ -1,6 +1,7 @@
 -- Rollback: revert app_settings schema changes
 ALTER TABLE app_settings DROP CONSTRAINT IF EXISTS idx_app_settings_scope_key;
 ALTER TABLE app_settings DROP CONSTRAINT IF EXISTS app_settings_pkey;
-ALTER TABLE app_settings ADD PRIMARY KEY (key);
+-- Drop scope before re-adding key-only PK to avoid duplicate keys across scopes
 ALTER TABLE app_settings DROP COLUMN IF EXISTS scope;
+ALTER TABLE app_settings ADD PRIMARY KEY (key);
 ALTER TABLE app_settings DROP COLUMN IF EXISTS id;

--- a/migrations/040_update_app_settings_schema.up.sql
+++ b/migrations/040_update_app_settings_schema.up.sql
@@ -1,0 +1,21 @@
+-- Migration: update app_settings schema
+-- Description: Add id (auto-increment PK) and scope columns to app_settings.
+--              The scope column allows RentalCore and WarehouseCore to store
+--              settings under different scopes while sharing the same table.
+--              A unique constraint on (scope, key) replaces the old key-only PK.
+
+-- Add id column as the new primary key
+ALTER TABLE app_settings ADD COLUMN IF NOT EXISTS id SERIAL;
+
+-- Add scope column (default 'global' so existing rows are migrated automatically)
+ALTER TABLE app_settings ADD COLUMN IF NOT EXISTS scope VARCHAR(50) NOT NULL DEFAULT 'global';
+
+-- Drop the old primary key constraint on key
+ALTER TABLE app_settings DROP CONSTRAINT IF EXISTS app_settings_pkey;
+
+-- Make id the new primary key
+ALTER TABLE app_settings ADD PRIMARY KEY (id);
+
+-- Add unique constraint on (scope, key) to prevent duplicates and support ON CONFLICT upserts
+ALTER TABLE app_settings DROP CONSTRAINT IF EXISTS idx_app_settings_scope_key;
+ALTER TABLE app_settings ADD CONSTRAINT idx_app_settings_scope_key UNIQUE (scope, key);

--- a/migrations/040_update_app_settings_schema.up.sql
+++ b/migrations/040_update_app_settings_schema.up.sql
@@ -14,6 +14,9 @@ ALTER TABLE app_settings ADD COLUMN IF NOT EXISTS id INTEGER;
 CREATE SEQUENCE IF NOT EXISTS app_settings_id_seq;
 UPDATE app_settings SET id = nextval('app_settings_id_seq') WHERE id IS NULL;
 
+-- Step 3a: Advance the sequence to MAX(id) so future inserts never conflict with backfilled values
+SELECT setval('app_settings_id_seq', COALESCE((SELECT MAX(id) FROM app_settings), 1), true);
+
 -- Step 4: Attach the sequence as the default for future inserts and enforce NOT NULL
 ALTER TABLE app_settings ALTER COLUMN id SET DEFAULT nextval('app_settings_id_seq');
 ALTER TABLE app_settings ALTER COLUMN id SET NOT NULL;

--- a/migrations/040_update_app_settings_schema.up.sql
+++ b/migrations/040_update_app_settings_schema.up.sql
@@ -4,8 +4,12 @@
 --              settings under different scopes while sharing the same table.
 --              A unique constraint on (scope, key) replaces the old key-only PK.
 
--- Step 1: Add scope column (default 'global' so existing rows are migrated automatically)
-ALTER TABLE app_settings ADD COLUMN IF NOT EXISTS scope VARCHAR(50) NOT NULL DEFAULT 'global';
+-- Step 1: Add scope column without NOT NULL so it can be added to existing tables with data,
+--         then backfill any NULLs and enforce NOT NULL afterwards.
+ALTER TABLE app_settings ADD COLUMN IF NOT EXISTS scope VARCHAR(50) DEFAULT 'global';
+UPDATE app_settings SET scope = 'global' WHERE scope IS NULL;
+ALTER TABLE app_settings ALTER COLUMN scope SET DEFAULT 'global';
+ALTER TABLE app_settings ALTER COLUMN scope SET NOT NULL;
 
 -- Step 2: Add id column as a nullable integer initially (must backfill before enforcing NOT NULL / PK)
 ALTER TABLE app_settings ADD COLUMN IF NOT EXISTS id INTEGER;
@@ -31,5 +35,8 @@ ALTER TABLE app_settings DROP CONSTRAINT IF EXISTS app_settings_pkey;
 ALTER TABLE app_settings ADD PRIMARY KEY (id);
 
 -- Step 8: Add unique constraint on (scope, key) to prevent duplicates and support ON CONFLICT upserts
+--         Drop both the constraint and the index (GORM AutoMigrate creates an index, not a named constraint)
+--         to ensure the ADD CONSTRAINT succeeds regardless of how the unique relation was previously created.
 ALTER TABLE app_settings DROP CONSTRAINT IF EXISTS idx_app_settings_scope_key;
+DROP INDEX IF EXISTS idx_app_settings_scope_key;
 ALTER TABLE app_settings ADD CONSTRAINT idx_app_settings_scope_key UNIQUE (scope, key);

--- a/migrations/040_update_app_settings_schema.up.sql
+++ b/migrations/040_update_app_settings_schema.up.sql
@@ -1,32 +1,32 @@
 -- Migration: update app_settings schema
--- Description: Add id (auto-increment PK) and scope columns to app_settings.
+-- Description: Add scope and id columns to app_settings.
 --              The scope column allows RentalCore and WarehouseCore to store
 --              settings under different scopes while sharing the same table.
 --              A unique constraint on (scope, key) replaces the old key-only PK.
 
--- Add scope column first (default 'global' so existing rows are migrated automatically)
+-- Step 1: Add scope column (default 'global' so existing rows are migrated automatically)
 ALTER TABLE app_settings ADD COLUMN IF NOT EXISTS scope VARCHAR(50) NOT NULL DEFAULT 'global';
 
--- Add id column as a nullable integer (backfill before enforcing NOT NULL / PK)
+-- Step 2: Add id column as a nullable integer initially (must backfill before enforcing NOT NULL / PK)
 ALTER TABLE app_settings ADD COLUMN IF NOT EXISTS id INTEGER;
 
--- Backfill id for all existing rows using a sequence
+-- Step 3: Backfill id for all existing rows using a sequence
 CREATE SEQUENCE IF NOT EXISTS app_settings_id_seq;
 UPDATE app_settings SET id = nextval('app_settings_id_seq') WHERE id IS NULL;
 
--- Now attach the sequence as the default for future inserts
+-- Step 4: Attach the sequence as the default for future inserts and enforce NOT NULL
 ALTER TABLE app_settings ALTER COLUMN id SET DEFAULT nextval('app_settings_id_seq');
 ALTER TABLE app_settings ALTER COLUMN id SET NOT NULL;
 
--- Transfer ownership of the sequence to the column (so it is dropped with the table)
+-- Step 5: Transfer sequence ownership so it is dropped with the table
 ALTER SEQUENCE app_settings_id_seq OWNED BY app_settings.id;
 
--- Drop the old primary key constraint on key
+-- Step 6: Drop the old primary key constraint on key
 ALTER TABLE app_settings DROP CONSTRAINT IF EXISTS app_settings_pkey;
 
--- Make id the new primary key
+-- Step 7: Make id the new primary key
 ALTER TABLE app_settings ADD PRIMARY KEY (id);
 
--- Add unique constraint on (scope, key) to prevent duplicates and support ON CONFLICT upserts
+-- Step 8: Add unique constraint on (scope, key) to prevent duplicates and support ON CONFLICT upserts
 ALTER TABLE app_settings DROP CONSTRAINT IF EXISTS idx_app_settings_scope_key;
 ALTER TABLE app_settings ADD CONSTRAINT idx_app_settings_scope_key UNIQUE (scope, key);

--- a/migrations/040_update_app_settings_schema.up.sql
+++ b/migrations/040_update_app_settings_schema.up.sql
@@ -4,11 +4,22 @@
 --              settings under different scopes while sharing the same table.
 --              A unique constraint on (scope, key) replaces the old key-only PK.
 
--- Add id column as the new primary key
-ALTER TABLE app_settings ADD COLUMN IF NOT EXISTS id SERIAL;
-
--- Add scope column (default 'global' so existing rows are migrated automatically)
+-- Add scope column first (default 'global' so existing rows are migrated automatically)
 ALTER TABLE app_settings ADD COLUMN IF NOT EXISTS scope VARCHAR(50) NOT NULL DEFAULT 'global';
+
+-- Add id column as a nullable integer (backfill before enforcing NOT NULL / PK)
+ALTER TABLE app_settings ADD COLUMN IF NOT EXISTS id INTEGER;
+
+-- Backfill id for all existing rows using a sequence
+CREATE SEQUENCE IF NOT EXISTS app_settings_id_seq;
+UPDATE app_settings SET id = nextval('app_settings_id_seq') WHERE id IS NULL;
+
+-- Now attach the sequence as the default for future inserts
+ALTER TABLE app_settings ALTER COLUMN id SET DEFAULT nextval('app_settings_id_seq');
+ALTER TABLE app_settings ALTER COLUMN id SET NOT NULL;
+
+-- Transfer ownership of the sequence to the column (so it is dropped with the table)
+ALTER SEQUENCE app_settings_id_seq OWNED BY app_settings.id;
 
 -- Drop the old primary key constraint on key
 ALTER TABLE app_settings DROP CONSTRAINT IF EXISTS app_settings_pkey;

--- a/web/static/js/security-roles.js
+++ b/web/static/js/security-roles.js
@@ -169,7 +169,7 @@ class RoleManagement {
                             </div>
                             <div class="role-meta-item">
                                 <i class="bi bi-calendar-plus"></i>
-                                <span>Created ${role.createdAt ? new Date(role.createdAt).toLocaleDateString() : 'N/A'}</span>
+                                <span>Created ${role.createdAt ? new Date(role.createdAt).toISOString().slice(0, 10) : 'N/A'}</span>
                             </div>
                             <div class="role-meta-item">
                                 <i class="bi bi-shield"></i>
@@ -354,11 +354,11 @@ function viewRole(roleId) {
                 <div style="display: flex; flex-direction: column; gap: var(--space-sm);">
                     <div style="display: flex; justify-content: space-between; padding: var(--space-xs) 0; border-bottom: 1px solid var(--surface-3);">
                         <span style="color: var(--text-secondary);">Created:</span>
-                        <span style="font-family: var(--font-mono); color: var(--text-primary); font-size: 0.875rem;">${new Date(role.createdAt).toLocaleDateString()}</span>
+                        <span style="font-family: var(--font-mono); color: var(--text-primary); font-size: 0.875rem;">${new Date(role.createdAt).toISOString().slice(0, 10)}</span>
                     </div>
                     <div style="display: flex; justify-content: space-between; padding: var(--space-xs) 0; border-bottom: 1px solid var(--surface-3);">
                         <span style="color: var(--text-secondary);">Updated:</span>
-                        <span style="font-family: var(--font-mono); color: var(--text-primary); font-size: 0.875rem;">${new Date(role.updatedAt).toLocaleDateString()}</span>
+                        <span style="font-family: var(--font-mono); color: var(--text-primary); font-size: 0.875rem;">${new Date(role.updatedAt).toISOString().slice(0, 10)}</span>
                     </div>
                     <div style="display: flex; justify-content: space-between; padding: var(--space-xs) 0; border-bottom: 1px solid var(--surface-3);">
                         <span style="color: var(--text-secondary);">Permissions:</span>
@@ -777,7 +777,7 @@ function renderRoleUsers() {
         const fullName = `${firstName} ${lastName}`.trim() || user.username;
         
         const expiryText = user.userRoleData?.expiresAt ? 
-            `<span style="font-size: 0.75rem; color: var(--text-muted);">Expires: ${new Date(user.userRoleData.expiresAt).toLocaleDateString()}</span>` : 
+            `<span style="font-size: 0.75rem; color: var(--text-muted);">Expires: ${new Date(user.userRoleData.expiresAt).toISOString().slice(0, 10)}</span>` : 
             '<span style="font-size: 0.75rem; color: var(--text-muted);">No expiry</span>';
         
         return `

--- a/web/static/js/security-roles.js
+++ b/web/static/js/security-roles.js
@@ -1,4 +1,16 @@
 // Security Roles Management JavaScript
+
+// Date helper: format as local YYYY-MM-DD
+function toLocalDateStr(d) {
+    if (!d) return 'N/A';
+    const dt = new Date(d);
+    if (isNaN(dt.getTime())) return 'N/A';
+    const y = dt.getFullYear();
+    const m = String(dt.getMonth() + 1).padStart(2, '0');
+    const day = String(dt.getDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+}
+
 class RoleManagement {
     constructor() {
         this.roles = [];
@@ -169,7 +181,7 @@ class RoleManagement {
                             </div>
                             <div class="role-meta-item">
                                 <i class="bi bi-calendar-plus"></i>
-                                <span>Created ${role.createdAt ? new Date(role.createdAt).toISOString().slice(0, 10) : 'N/A'}</span>
+                                <span>Created ${toLocalDateStr(role.createdAt)}</span>
                             </div>
                             <div class="role-meta-item">
                                 <i class="bi bi-shield"></i>
@@ -354,11 +366,11 @@ function viewRole(roleId) {
                 <div style="display: flex; flex-direction: column; gap: var(--space-sm);">
                     <div style="display: flex; justify-content: space-between; padding: var(--space-xs) 0; border-bottom: 1px solid var(--surface-3);">
                         <span style="color: var(--text-secondary);">Created:</span>
-                        <span style="font-family: var(--font-mono); color: var(--text-primary); font-size: 0.875rem;">${new Date(role.createdAt).toISOString().slice(0, 10)}</span>
+                        <span style="font-family: var(--font-mono); color: var(--text-primary); font-size: 0.875rem;">${toLocalDateStr(role.createdAt)}</span>
                     </div>
                     <div style="display: flex; justify-content: space-between; padding: var(--space-xs) 0; border-bottom: 1px solid var(--surface-3);">
                         <span style="color: var(--text-secondary);">Updated:</span>
-                        <span style="font-family: var(--font-mono); color: var(--text-primary); font-size: 0.875rem;">${new Date(role.updatedAt).toISOString().slice(0, 10)}</span>
+                        <span style="font-family: var(--font-mono); color: var(--text-primary); font-size: 0.875rem;">${toLocalDateStr(role.updatedAt)}</span>
                     </div>
                     <div style="display: flex; justify-content: space-between; padding: var(--space-xs) 0; border-bottom: 1px solid var(--surface-3);">
                         <span style="color: var(--text-secondary);">Permissions:</span>
@@ -777,7 +789,7 @@ function renderRoleUsers() {
         const fullName = `${firstName} ${lastName}`.trim() || user.username;
         
         const expiryText = user.userRoleData?.expiresAt ? 
-            `<span style="font-size: 0.75rem; color: var(--text-muted);">Expires: ${new Date(user.userRoleData.expiresAt).toISOString().slice(0, 10)}</span>` : 
+            `<span style="font-size: 0.75rem; color: var(--text-muted);">Expires: ${toLocalDateStr(user.userRoleData.expiresAt)}</span>` : 
             '<span style="font-size: 0.75rem; color: var(--text-muted);">No expiry</span>';
         
         return `

--- a/web/templates/documents_list.html
+++ b/web/templates/documents_list.html
@@ -230,7 +230,7 @@
                                     {{if .Uploader}}by {{.Uploader.Username}}{{end}}
                                 </small>
                                 <small class="text-muted">
-                                    {{.UploadedAt.Format "Jan 2, 2006"}}
+                                    {{.UploadedAt.Format "2006-01-02"}}
                                 </small>
                             </div>
                         </div>

--- a/web/templates/job_detail.html
+++ b/web/templates/job_detail.html
@@ -600,15 +600,8 @@
 
         history.forEach((entry, index) => {
             const changeDate = new Date(entry.changed_at);
-            const formattedDate = changeDate.toLocaleDateString('de-DE', {
-                year: 'numeric',
-                month: '2-digit',
-                day: '2-digit'
-            });
-            const formattedTime = changeDate.toLocaleTimeString('de-DE', {
-                hour: '2-digit',
-                minute: '2-digit'
-            });
+            const formattedDate = changeDate.toISOString().slice(0, 10);
+            const formattedTime = changeDate.toISOString().slice(11, 16);
 
             // Get icon and badge color based on change type
             const typeInfo = getChangeTypeInfo(entry.change_type);
@@ -765,7 +758,7 @@
         attachments.forEach(attachment => {
             const isImage = attachment.isImage;
             const iconClass = getFileIcon(attachment.mimeType);
-            const uploadDate = new Date(attachment.uploadedAt).toLocaleDateString('de-DE');
+            const uploadDate = new Date(attachment.uploadedAt).toISOString().slice(0, 10);
 
             html += `
                 <div class="attachment-item rc-flex rc-flex-between rc-p-md rc-border-bottom">

--- a/web/templates/job_detail.html
+++ b/web/templates/job_detail.html
@@ -600,13 +600,7 @@
 
         history.forEach((entry, index) => {
             const changeDate = new Date(entry.changed_at);
-            const formattedDate = (() => {
-                if (isNaN(changeDate.getTime())) return '';
-                const y = changeDate.getFullYear();
-                const mo = String(changeDate.getMonth() + 1).padStart(2, '0');
-                const d = String(changeDate.getDate()).padStart(2, '0');
-                return `${y}-${mo}-${d}`;
-            })();
+            const formattedDate = toLocalDateStr(changeDate);
             const formattedTime = isNaN(changeDate.getTime()) ? '' :
                 String(changeDate.getHours()).padStart(2, '0') + ':' + String(changeDate.getMinutes()).padStart(2, '0');
 
@@ -765,15 +759,7 @@
         attachments.forEach(attachment => {
             const isImage = attachment.isImage;
             const iconClass = getFileIcon(attachment.mimeType);
-            const uploadDate = (() => {
-                if (!attachment.uploadedAt) return '';
-                const d = new Date(attachment.uploadedAt);
-                if (isNaN(d.getTime())) return '';
-                const y = d.getFullYear();
-                const m = String(d.getMonth() + 1).padStart(2, '0');
-                const day = String(d.getDate()).padStart(2, '0');
-                return `${y}-${m}-${day}`;
-            })();
+            const uploadDate = toLocalDateStr(attachment.uploadedAt);
 
             html += `
                 <div class="attachment-item rc-flex rc-flex-between rc-p-md rc-border-bottom">
@@ -940,6 +926,16 @@
     }
 
     // Helper functions
+    function toLocalDateStr(d) {
+        if (!d) return '';
+        const dt = new Date(d);
+        if (isNaN(dt.getTime())) return '';
+        const y = dt.getFullYear();
+        const m = String(dt.getMonth() + 1).padStart(2, '0');
+        const day = String(dt.getDate()).padStart(2, '0');
+        return `${y}-${m}-${day}`;
+    }
+
     function getFileIcon(mimeType) {
         if (mimeType.startsWith('image/')) return 'bi-image';
         if (mimeType.startsWith('video/')) return 'bi-play-circle';

--- a/web/templates/job_detail.html
+++ b/web/templates/job_detail.html
@@ -600,8 +600,15 @@
 
         history.forEach((entry, index) => {
             const changeDate = new Date(entry.changed_at);
-            const formattedDate = changeDate.toISOString().slice(0, 10);
-            const formattedTime = changeDate.toISOString().slice(11, 16);
+            const formattedDate = (() => {
+                if (isNaN(changeDate.getTime())) return '';
+                const y = changeDate.getFullYear();
+                const mo = String(changeDate.getMonth() + 1).padStart(2, '0');
+                const d = String(changeDate.getDate()).padStart(2, '0');
+                return `${y}-${mo}-${d}`;
+            })();
+            const formattedTime = isNaN(changeDate.getTime()) ? '' :
+                String(changeDate.getHours()).padStart(2, '0') + ':' + String(changeDate.getMinutes()).padStart(2, '0');
 
             // Get icon and badge color based on change type
             const typeInfo = getChangeTypeInfo(entry.change_type);
@@ -758,7 +765,15 @@
         attachments.forEach(attachment => {
             const isImage = attachment.isImage;
             const iconClass = getFileIcon(attachment.mimeType);
-            const uploadDate = new Date(attachment.uploadedAt).toISOString().slice(0, 10);
+            const uploadDate = (() => {
+                if (!attachment.uploadedAt) return '';
+                const d = new Date(attachment.uploadedAt);
+                if (isNaN(d.getTime())) return '';
+                const y = d.getFullYear();
+                const m = String(d.getMonth() + 1).padStart(2, '0');
+                const day = String(d.getDate()).padStart(2, '0');
+                return `${y}-${m}-${day}`;
+            })();
 
             html += `
                 <div class="attachment-item rc-flex rc-flex-between rc-p-md rc-border-bottom">

--- a/web/templates/job_detail.html
+++ b/web/templates/job_detail.html
@@ -186,11 +186,11 @@
                             {{end}}
                             <div class="info-item">
                                 <label>Start Date</label>
-                                <span>{{if .job.StartDate}}{{.job.StartDate.Format "02.01.2006"}}{{else}}-{{end}}</span>
+                                <span>{{if .job.StartDate}}{{.job.StartDate.Format "2006-01-02"}}{{else}}-{{end}}</span>
                             </div>
                             <div class="info-item">
                                 <label>End Date</label>
-                                <span>{{if .job.EndDate}}{{.job.EndDate.Format "02.01.2006"}}{{else}}-{{end}}</span>
+                                <span>{{if .job.EndDate}}{{.job.EndDate.Format "2006-01-02"}}{{else}}-{{end}}</span>
                             </div>
                             <div class="info-item">
                                 <label>Revenue</label>
@@ -218,7 +218,7 @@
                                 {{if .job.CreatedAt}}
                                 <div class="rc-mb-xs">
                                     <span class="rc-text-secondary">Created:</span>
-                                    <span id="created-info">{{.job.CreatedAt.Format "02.01.2006 15:04"}}
+                                    <span id="created-info">{{.job.CreatedAt.Format "2006-01-02 15:04"}}
                                         {{if .job.Creator}}
                                             by {{.job.Creator.GetDisplayName}}
                                         {{end}}
@@ -228,7 +228,7 @@
                                 {{if .job.UpdatedAt}}
                                 <div>
                                     <span class="rc-text-secondary">Last edited:</span>
-                                    <span id="updated-info">{{.job.UpdatedAt.Format "02.01.2006 15:04"}}</span>
+                                    <span id="updated-info">{{.job.UpdatedAt.Format "2006-01-02 15:04"}}</span>
                                 </div>
                                 {{end}}
                             </div>

--- a/web/templates/job_form.html
+++ b/web/templates/job_form.html
@@ -168,7 +168,7 @@
                     {{if .job.UpdatedAt}}
                     <div class="rc-text-xs rc-text-secondary" style="margin-top: 0.25rem;">
                         <i class="bi bi-clock-history"></i>
-                        Last edited: {{.job.UpdatedAt.Format "02.01.2006 15:04"}}
+                        Last edited: {{.job.UpdatedAt.Format "2006-01-02 15:04"}}
                     </div>
                     {{end}}
                     {{end}}

--- a/web/templates/jobs.html
+++ b/web/templates/jobs.html
@@ -314,7 +314,29 @@
         }
     }
 
-    const appCurrencySymbol = '{{currencySymbol}}' || '€';
+    const appCurrencySymbol = (window.__APP_CONFIG__ && window.__APP_CONFIG__.currencySymbol) || '{{currencySymbol}}';
+
+    function toLocalDateStr(d) {
+        if (!d) return '';
+        const dt = new Date(d);
+        if (isNaN(dt.getTime())) return '';
+        const y = dt.getFullYear();
+        const m = String(dt.getMonth() + 1).padStart(2, '0');
+        const day = String(dt.getDate()).padStart(2, '0');
+        return `${y}-${m}-${day}`;
+    }
+
+    function toLocalDateTimeStr(d) {
+        if (!d) return '';
+        const dt = new Date(d);
+        if (isNaN(dt.getTime())) return '';
+        const y = dt.getFullYear();
+        const m = String(dt.getMonth() + 1).padStart(2, '0');
+        const day = String(dt.getDate()).padStart(2, '0');
+        const h = String(dt.getHours()).padStart(2, '0');
+        const min = String(dt.getMinutes()).padStart(2, '0');
+        return `${y}-${m}-${day} ${h}:${min}`;
+    }
 
     // Job Details Modal
     function showJobDetails(jobID) {
@@ -370,8 +392,8 @@
                                 </button>
                             </div>
                         </div>
-                        ${jobData.startDate ? '<div class="rc-form-group"><label class="rc-label">' + (_t ? _t('jobs.startDate') : 'Start Date') + '</label><div><i class="bi bi-calendar"></i> ' + new Date(jobData.startDate).toISOString().slice(0, 10) + '</div></div>' : ''}
-                        ${jobData.endDate ? '<div class="rc-form-group"><label class="rc-label">' + (_t ? _t('jobs.endDate') : 'End Date') + '</label><div><i class="bi bi-calendar"></i> ' + new Date(jobData.endDate).toISOString().slice(0, 10) + '</div></div>' : ''}
+                        ${jobData.startDate ? '<div class="rc-form-group"><label class="rc-label">' + (_t ? _t('jobs.startDate') : 'Start Date') + '</label><div><i class="bi bi-calendar"></i> ' + toLocalDateStr(jobData.startDate) + '</div></div>' : ''}
+                        ${jobData.endDate ? '<div class="rc-form-group"><label class="rc-label">' + (_t ? _t('jobs.endDate') : 'End Date') + '</label><div><i class="bi bi-calendar"></i> ' + toLocalDateStr(jobData.endDate) + '</div></div>' : ''}
                         ${jobData.discount > 0 ? '<div class="rc-form-group"><label class="rc-label">' + (_t ? _t('jobs.discount') : 'Discount') + '</label><div>' + jobData.discount + ' ' + (jobData.discount_type === 'percent' ? '%' : appCurrencySymbol) + '</div></div>' : ''}
                         ${jobData.finalRevenue ? '<div class="rc-form-group"><label class="rc-label">' + (_t ? _t('jobs.finalRevenue') : 'Final Revenue') + '</label><div class="rc-text-lg">' + appCurrencySymbol + jobData.finalRevenue.toFixed(2) + '</div></div>' : ''}
                     </div>
@@ -389,8 +411,8 @@
                         <div class="rc-card" style="background: var(--surface-1); border: 1px solid var(--surface-3);">
                             <div class="rc-card-body">
                                 <div class="rc-text-sm">
-                                    ${jobData.created_at ? '<div class="rc-mb-xs"><span class="rc-text-secondary">Created:</span> <span>' + new Date(jobData.created_at).toISOString().slice(0, 16).replace('T', ' ') + '</span></div>' : ''}
-                                    ${jobData.updated_at ? '<div><span class="rc-text-secondary">Last edited:</span> <span>' + new Date(jobData.updated_at).toISOString().slice(0, 16).replace('T', ' ') + '</span></div>' : ''}
+                                    ${jobData.created_at ? '<div class="rc-mb-xs"><span class="rc-text-secondary">Created:</span> <span>' + toLocalDateTimeStr(jobData.created_at) + '</span></div>' : ''}
+                                    ${jobData.updated_at ? '<div><span class="rc-text-secondary">Last edited:</span> <span>' + toLocalDateTimeStr(jobData.updated_at) + '</span></div>' : ''}
                                 </div>
                             </div>
                         </div>
@@ -3528,7 +3550,7 @@ function showToast(message, type) {
                                     <div style="font-size: 12px; color: var(--text-muted);">
                                         ${attachment.fileSizeFormatted}
                                         ${attachment.uploader ? ` • by ${attachment.uploader.firstName} ${attachment.uploader.lastName}` : ''}
-                                        • ${new Date(attachment.uploadedAt).toISOString().slice(0, 10)}
+                                        • ${toLocalDateStr(attachment.uploadedAt)}
                                     </div>
                                 </div>
                             </div>
@@ -5910,7 +5932,30 @@ function showToast(message, type) {
         }
 
         function formatDate(dateStr) {
-            return new Date(dateStr).toISOString().slice(0, 10);
+            if (!dateStr || typeof dateStr !== 'string') {
+                return '';
+            }
+
+            const trimmed = dateStr.trim();
+            if (!trimmed) {
+                return '';
+            }
+
+            // Handle YYYY-MM-DD and YYYY-MM-DD HH:MM:SS formats directly
+            // (returned by the PDF pool endpoint) without UTC conversion.
+            if (/^\d{4}-\d{2}-\d{2}(?: \d{2}:\d{2}(:\d{2})?)?$/.test(trimmed)) {
+                return trimmed.slice(0, 10);
+            }
+
+            const parsed = new Date(trimmed);
+            if (isNaN(parsed.getTime())) {
+                return '';
+            }
+
+            const y = parsed.getFullYear();
+            const m = String(parsed.getMonth() + 1).padStart(2, '0');
+            const d = String(parsed.getDate()).padStart(2, '0');
+            return `${y}-${m}-${d}`;
         }
 
         function processPdfSource() {
@@ -6090,8 +6135,8 @@ function showToast(message, type) {
 
             history.forEach((entry, index) => {
                 const changeDate = new Date(entry.changed_at);
-                const formattedDate = changeDate.toISOString().slice(0, 10);
-                const formattedTime = changeDate.toISOString().slice(11, 16);
+                const formattedDate = toLocalDateStr(changeDate);
+                const formattedTime = String(changeDate.getHours()).padStart(2, '0') + ':' + String(changeDate.getMinutes()).padStart(2, '0');
 
                 const typeInfo = getHistoryChangeTypeInfo(entry.change_type);
 

--- a/web/templates/jobs.html
+++ b/web/templates/jobs.html
@@ -368,8 +368,8 @@
                                 </button>
                             </div>
                         </div>
-                        ${jobData.startDate ? '<div class="rc-form-group"><label class="rc-label">' + (_t ? _t('jobs.startDate') : 'Start Date') + '</label><div><i class="bi bi-calendar"></i> ' + new Date(jobData.startDate).toLocaleDateString() + '</div></div>' : ''}
-                        ${jobData.endDate ? '<div class="rc-form-group"><label class="rc-label">' + (_t ? _t('jobs.endDate') : 'End Date') + '</label><div><i class="bi bi-calendar"></i> ' + new Date(jobData.endDate).toLocaleDateString() + '</div></div>' : ''}
+                        ${jobData.startDate ? '<div class="rc-form-group"><label class="rc-label">' + (_t ? _t('jobs.startDate') : 'Start Date') + '</label><div><i class="bi bi-calendar"></i> ' + new Date(jobData.startDate).toISOString().slice(0, 10) + '</div></div>' : ''}
+                        ${jobData.endDate ? '<div class="rc-form-group"><label class="rc-label">' + (_t ? _t('jobs.endDate') : 'End Date') + '</label><div><i class="bi bi-calendar"></i> ' + new Date(jobData.endDate).toISOString().slice(0, 10) + '</div></div>' : ''}
                         ${jobData.discount > 0 ? '<div class="rc-form-group"><label class="rc-label">' + (_t ? _t('jobs.discount') : 'Discount') + '</label><div>' + jobData.discount + ' ' + (jobData.discount_type === 'percent' ? '%' : '€') + '</div></div>' : ''}
                         ${jobData.finalRevenue ? '<div class="rc-form-group"><label class="rc-label">' + (_t ? _t('jobs.finalRevenue') : 'Final Revenue') + '</label><div class="rc-text-lg">€' + jobData.finalRevenue.toFixed(2) + '</div></div>' : ''}
                     </div>
@@ -387,8 +387,8 @@
                         <div class="rc-card" style="background: var(--surface-1); border: 1px solid var(--surface-3);">
                             <div class="rc-card-body">
                                 <div class="rc-text-sm">
-                                    ${jobData.created_at ? '<div class="rc-mb-xs"><span class="rc-text-secondary">Created:</span> <span>' + new Date(jobData.created_at).toLocaleDateString('de-DE') + ' ' + new Date(jobData.created_at).toLocaleTimeString('de-DE', {hour: '2-digit', minute: '2-digit'}) + '</span></div>' : ''}
-                                    ${jobData.updated_at ? '<div><span class="rc-text-secondary">Last edited:</span> <span>' + new Date(jobData.updated_at).toLocaleDateString('de-DE') + ' ' + new Date(jobData.updated_at).toLocaleTimeString('de-DE', {hour: '2-digit', minute: '2-digit'}) + '</span></div>' : ''}
+                                    ${jobData.created_at ? '<div class="rc-mb-xs"><span class="rc-text-secondary">Created:</span> <span>' + new Date(jobData.created_at).toISOString().slice(0, 16).replace('T', ' ') + '</span></div>' : ''}
+                                    ${jobData.updated_at ? '<div><span class="rc-text-secondary">Last edited:</span> <span>' + new Date(jobData.updated_at).toISOString().slice(0, 16).replace('T', ' ') + '</span></div>' : ''}
                                 </div>
                             </div>
                         </div>
@@ -779,7 +779,8 @@
             fetch('/api/v1/jobs/' + jobID),
             fetch('/api/v1/customers'),
             fetch('/statuses'),
-            fetch('/api/v1/jobs/' + jobID + '/devices')
+            fetch('/api/v1/jobs/' + jobID + '/devices'),
+            fetch('/api/v1/jobs/' + jobID + '/product-requirements')
         ])
         .then(responses => {
             // Check if all responses are ok before parsing JSON
@@ -790,11 +791,12 @@
             });
             return Promise.all(responses.map(r => r.json()));
         })
-        .then(([jobResponse, customersResponse, statusResponse, devicesResponse]) => {
+        .then(([jobResponse, customersResponse, statusResponse, devicesResponse, requirementsResponse]) => {
             const job = jobResponse.job || jobResponse;
             const customers = customersResponse.customers || customersResponse;
             const statuses = statusResponse.statuses || statusResponse;
             const existingDevices = devicesResponse.devices || [];
+            const productRequirements = Array.isArray(requirementsResponse) ? requirementsResponse : [];
             
             console.log('Job edit data:', {job, customers, statuses});
             
@@ -1034,7 +1036,7 @@
                 editProductTreeControlsBound = true;
             }
 
-            initializeEditProductSelections(job.jobID, existingDevices);
+            initializeEditProductSelections(job.jobID, existingDevices, productRequirements);
             loadEditAssignedDevices(job.jobID, existingDevices);
             refreshJobRentalEquipment(job.jobID);
         })
@@ -1459,12 +1461,25 @@
     let editProductTreeControlsBound = false;
     let editProductTreeExpanded = new Set();
 
-    function initializeEditProductSelections(jobID, existingDevices) {
+    function initializeEditProductSelections(jobID, existingDevices, productRequirements) {
         editProductSelections = new Map();
         editInitialProductSelections = new Map();
         editProductValidationErrors = [];
 
-        if (Array.isArray(existingDevices)) {
+        // Prefer product requirements (planned quantities) over actual device counts
+        if (Array.isArray(productRequirements) && productRequirements.length > 0) {
+            productRequirements.forEach(req => {
+                const product = req.product || {};
+                const productID = req.product_id || product.productID || product.ProductID;
+                if (!productID) return;
+                const productName = product.name || product.Name || `Product ${productID}`;
+                const quantity = req.quantity || 0;
+                const entry = { id: productID, name: productName, available: 0, total: 0, quantity };
+                editInitialProductSelections.set(String(productID), entry);
+                editProductSelections.set(String(productID), { ...entry });
+            });
+        } else if (Array.isArray(existingDevices)) {
+            // Fall back to counting actual device assignments grouped by product
             const counts = new Map();
             existingDevices.forEach(deviceEntry => {
                 const device = deviceEntry.device || deviceEntry;
@@ -3511,7 +3526,7 @@ function showToast(message, type) {
                                     <div style="font-size: 12px; color: var(--text-muted);">
                                         ${attachment.fileSizeFormatted}
                                         ${attachment.uploader ? ` • by ${attachment.uploader.firstName} ${attachment.uploader.lastName}` : ''}
-                                        • ${new Date(attachment.uploadedAt).toLocaleDateString()}
+                                        • ${new Date(attachment.uploadedAt).toISOString().slice(0, 10)}
                                     </div>
                                 </div>
                             </div>
@@ -5893,8 +5908,7 @@ function showToast(message, type) {
         }
 
         function formatDate(dateStr) {
-            const date = new Date(dateStr);
-            return date.toLocaleDateString('de-DE', { day: '2-digit', month: 'short' });
+            return new Date(dateStr).toISOString().slice(0, 10);
         }
 
         function processPdfSource() {
@@ -6074,15 +6088,8 @@ function showToast(message, type) {
 
             history.forEach((entry, index) => {
                 const changeDate = new Date(entry.changed_at);
-                const formattedDate = changeDate.toLocaleDateString('de-DE', {
-                    year: 'numeric',
-                    month: '2-digit',
-                    day: '2-digit'
-                });
-                const formattedTime = changeDate.toLocaleTimeString('de-DE', {
-                    hour: '2-digit',
-                    minute: '2-digit'
-                });
+                const formattedDate = changeDate.toISOString().slice(0, 10);
+                const formattedTime = changeDate.toISOString().slice(11, 16);
 
                 const typeInfo = getHistoryChangeTypeInfo(entry.change_type);
 

--- a/web/templates/jobs.html
+++ b/web/templates/jobs.html
@@ -140,8 +140,8 @@
                                             <div class="rc-table-wc-title">{{.CustomerName}}</div>
                                             <div class="rc-table-wc-sub">{{if .CategoryName}}{{.CategoryName}}{{else}}<span data-i18n="jobs.noCategory">No category</span>{{end}}</div>
                                         </td>
-                                        <td><span class="rc-table-wc-sub">{{if .StartDate}}{{.StartDate.Format "02.01.2006"}}{{else}}-{{end}}</span></td>
-                                        <td><span class="rc-table-wc-sub">{{if .EndDate}}{{.EndDate.Format "02.01.2006"}}{{else}}-{{end}}</span></td>
+                                        <td><span class="rc-table-wc-sub">{{if .StartDate}}{{.StartDate.Format "2006-01-02"}}{{else}}-{{end}}</span></td>
+                                        <td><span class="rc-table-wc-sub">{{if .EndDate}}{{.EndDate.Format "2006-01-02"}}{{else}}-{{end}}</span></td>
                                         <td><span class="rc-badge rc-badge-secondary">{{.StatusName}}</span></td>
                                         <td><span class="rc-table-wc-sub">{{.DeviceCount}} <span data-i18n="jobs.devicesLabel">devices</span></span></td>
                                         <td style="text-align: right;"><span class="rc-table-wc-title">€{{printf "%.2f" .TotalRevenue}}</span></td>

--- a/web/templates/jobs.html
+++ b/web/templates/jobs.html
@@ -6137,8 +6137,11 @@ function showToast(message, type) {
 
             history.forEach((entry, index) => {
                 const changeDate = new Date(entry.changed_at);
-                const formattedDate = toLocalDateStr(changeDate);
-                const formattedTime = String(changeDate.getHours()).padStart(2, '0') + ':' + String(changeDate.getMinutes()).padStart(2, '0');
+                const isValidDate = entry.changed_at && !isNaN(changeDate.getTime());
+                const formattedDate = isValidDate ? toLocalDateStr(changeDate) : '';
+                const formattedTime = isValidDate
+                    ? String(changeDate.getHours()).padStart(2, '0') + ':' + String(changeDate.getMinutes()).padStart(2, '0')
+                    : '';
 
                 const typeInfo = getHistoryChangeTypeInfo(entry.change_type);
 

--- a/web/templates/jobs.html
+++ b/web/templates/jobs.html
@@ -315,6 +315,8 @@
     }
 
     const appCurrencySymbol = (window.__APP_CONFIG__ && window.__APP_CONFIG__.currencySymbol) || '{{currencySymbol}}';
+    // Pre-escape the currency symbol for safe insertion into innerHTML strings.
+    const appCurrencySymbolHtml = appCurrencySymbol.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#039;');
 
     function toLocalDateStr(d) {
         if (!d) return '';
@@ -382,7 +384,7 @@
                         </div>
                         <div class="rc-form-group">
                             <label class="rc-label">${_t ? _t('jobs.revenue') : 'Revenue'}</label>
-                            <div class="rc-text-lg">${appCurrencySymbol}${(jobData.revenue || 0).toFixed(2)}</div>
+                            <div class="rc-text-lg">${appCurrencySymbolHtml}${(jobData.revenue || 0).toFixed(2)}</div>
                         </div>
                         <div class="rc-form-group">
                             <label class="rc-label">${_t ? _t('jobs.devices_label') : 'Devices'}</label>
@@ -394,8 +396,8 @@
                         </div>
                         ${jobData.startDate ? '<div class="rc-form-group"><label class="rc-label">' + (_t ? _t('jobs.startDate') : 'Start Date') + '</label><div><i class="bi bi-calendar"></i> ' + toLocalDateStr(jobData.startDate) + '</div></div>' : ''}
                         ${jobData.endDate ? '<div class="rc-form-group"><label class="rc-label">' + (_t ? _t('jobs.endDate') : 'End Date') + '</label><div><i class="bi bi-calendar"></i> ' + toLocalDateStr(jobData.endDate) + '</div></div>' : ''}
-                        ${jobData.discount > 0 ? '<div class="rc-form-group"><label class="rc-label">' + (_t ? _t('jobs.discount') : 'Discount') + '</label><div>' + jobData.discount + ' ' + (jobData.discount_type === 'percent' ? '%' : appCurrencySymbol) + '</div></div>' : ''}
-                        ${jobData.finalRevenue ? '<div class="rc-form-group"><label class="rc-label">' + (_t ? _t('jobs.finalRevenue') : 'Final Revenue') + '</label><div class="rc-text-lg">' + appCurrencySymbol + jobData.finalRevenue.toFixed(2) + '</div></div>' : ''}
+                        ${jobData.discount > 0 ? '<div class="rc-form-group"><label class="rc-label">' + (_t ? _t('jobs.discount') : 'Discount') + '</label><div>' + jobData.discount + ' ' + (jobData.discount_type === 'percent' ? '%' : appCurrencySymbolHtml) + '</div></div>' : ''}
+                        ${jobData.finalRevenue ? '<div class="rc-form-group"><label class="rc-label">' + (_t ? _t('jobs.finalRevenue') : 'Final Revenue') + '</label><div class="rc-text-lg">' + appCurrencySymbolHtml + jobData.finalRevenue.toFixed(2) + '</div></div>' : ''}
                     </div>
 
                     <!-- Job History Section -->
@@ -724,7 +726,7 @@
                             <br><small class="rc-text-muted">${escapeHtml(deviceId || 'Unknown ID')}</small>
                         </div>
                         <div class="rc-text-sm rc-text-secondary" title="${customPrice ? 'Custom price set for this device' : 'Price from product'}">
-                            ${appCurrencySymbol}${priceLabel}${priceNote}
+                            ${appCurrencySymbolHtml}${priceLabel}${priceNote}
                         </div>
                     </div>
                 `;
@@ -852,7 +854,7 @@
                             </select>
                         </div>
                         <div class="rc-form-group">
-                            <label class="rc-label">Revenue (${appCurrencySymbol})</label>
+                            <label class="rc-label">Revenue (${appCurrencySymbolHtml})</label>
                             <input type="number" class="rc-input" name="revenue" value="${job.revenue || ''}" step="0.01" min="0">
                         </div>
                         <div class="rc-form-group">
@@ -870,7 +872,7 @@
                         <div class="rc-form-group">
                             <label class="rc-label">Discount Type</label>
                             <select class="rc-select" name="discount_type">
-                                <option value="amount" ${job.discount_type === 'amount' ? 'selected' : ''}>Amount (${appCurrencySymbol})</option>
+                                <option value="amount" ${job.discount_type === 'amount' ? 'selected' : ''}>Amount (${appCurrencySymbolHtml})</option>
                                 <option value="percent" ${job.discount_type === 'percent' ? 'selected' : ''}>Percentage (%)</option>
                             </select>
                         </div>
@@ -2794,7 +2796,7 @@
                                        step="0.01"
                                        onchange="updateDevicePrice(${jobID}, '${deviceID}', this.value)"
                                        placeholder="${price.toFixed(2)}">
-                                <span class="rc-text-xs">${appCurrencySymbol}/day</span>
+                                <span class="rc-text-xs">${appCurrencySymbolHtml}/day</span>
                                 <button type="button" onclick="removeDeviceFromEditJob(${jobID}, '${deviceID}')"
                                         class="rc-btn rc-btn-outline rc-btn-sm"
                                         style="padding: 2px 6px;"
@@ -3074,7 +3076,7 @@
                                        step="0.01"
                                        onchange="updateDevicePrice(${jobID}, '${device.device?.deviceID}', this.value)"
                                        placeholder="0.00">
-                                <span class="rc-text-sm">${appCurrencySymbol}</span>
+                                <span class="rc-text-sm">${appCurrencySymbolHtml}</span>
                             </div>
                         </div>
                     `;
@@ -3153,7 +3155,7 @@
                     const revenueCell = jobRow.querySelector('td:nth-child(8)'); // Revenue column
                     if (revenueCell) {
                         const newRevenue = data.finalRevenue || data.revenue || 0;
-                        revenueCell.innerHTML = `<span class="rc-text-mono">${appCurrencySymbol}${newRevenue.toFixed(2)}</span>`;
+                        revenueCell.innerHTML = `<span class="rc-text-mono">${appCurrencySymbolHtml}${newRevenue.toFixed(2)}</span>`;
                     }
                 }
                 

--- a/web/templates/jobs.html
+++ b/web/templates/jobs.html
@@ -144,7 +144,7 @@
                                         <td><span class="rc-table-wc-sub">{{if .EndDate}}{{.EndDate.Format "2006-01-02"}}{{else}}-{{end}}</span></td>
                                         <td><span class="rc-badge rc-badge-secondary">{{.StatusName}}</span></td>
                                         <td><span class="rc-table-wc-sub">{{.DeviceCount}} <span data-i18n="jobs.devicesLabel">devices</span></span></td>
-                                        <td style="text-align: right;"><span class="rc-table-wc-title">€{{printf "%.2f" .TotalRevenue}}</span></td>
+                                        <td style="text-align: right;"><span class="rc-table-wc-title">{{currencySymbol}}{{printf "%.2f" .TotalRevenue}}</span></td>
                                         <td style="text-align: right;" onclick="event.stopPropagation()">
                                             <div class="rc-flex rc-flex-gap-xs" style="justify-content: flex-end;">
                                                 <button type="button" class="rc-icon-btn" data-i18n-attr="title:jobs.view" onclick="showJobDetails({{.JobID}})">
@@ -314,6 +314,8 @@
         }
     }
 
+    const appCurrencySymbol = '{{currencySymbol}}' || '€';
+
     // Job Details Modal
     function showJobDetails(jobID) {
         const modal = document.getElementById('jobDetailsModal');
@@ -358,7 +360,7 @@
                         </div>
                         <div class="rc-form-group">
                             <label class="rc-label">${_t ? _t('jobs.revenue') : 'Revenue'}</label>
-                            <div class="rc-text-lg">€${(jobData.revenue || 0).toFixed(2)}</div>
+                            <div class="rc-text-lg">${appCurrencySymbol}${(jobData.revenue || 0).toFixed(2)}</div>
                         </div>
                         <div class="rc-form-group">
                             <label class="rc-label">${_t ? _t('jobs.devices_label') : 'Devices'}</label>
@@ -370,8 +372,8 @@
                         </div>
                         ${jobData.startDate ? '<div class="rc-form-group"><label class="rc-label">' + (_t ? _t('jobs.startDate') : 'Start Date') + '</label><div><i class="bi bi-calendar"></i> ' + new Date(jobData.startDate).toISOString().slice(0, 10) + '</div></div>' : ''}
                         ${jobData.endDate ? '<div class="rc-form-group"><label class="rc-label">' + (_t ? _t('jobs.endDate') : 'End Date') + '</label><div><i class="bi bi-calendar"></i> ' + new Date(jobData.endDate).toISOString().slice(0, 10) + '</div></div>' : ''}
-                        ${jobData.discount > 0 ? '<div class="rc-form-group"><label class="rc-label">' + (_t ? _t('jobs.discount') : 'Discount') + '</label><div>' + jobData.discount + ' ' + (jobData.discount_type === 'percent' ? '%' : '€') + '</div></div>' : ''}
-                        ${jobData.finalRevenue ? '<div class="rc-form-group"><label class="rc-label">' + (_t ? _t('jobs.finalRevenue') : 'Final Revenue') + '</label><div class="rc-text-lg">€' + jobData.finalRevenue.toFixed(2) + '</div></div>' : ''}
+                        ${jobData.discount > 0 ? '<div class="rc-form-group"><label class="rc-label">' + (_t ? _t('jobs.discount') : 'Discount') + '</label><div>' + jobData.discount + ' ' + (jobData.discount_type === 'percent' ? '%' : appCurrencySymbol) + '</div></div>' : ''}
+                        ${jobData.finalRevenue ? '<div class="rc-form-group"><label class="rc-label">' + (_t ? _t('jobs.finalRevenue') : 'Final Revenue') + '</label><div class="rc-text-lg">' + appCurrencySymbol + jobData.finalRevenue.toFixed(2) + '</div></div>' : ''}
                     </div>
 
                     <!-- Job History Section -->
@@ -700,7 +702,7 @@
                             <br><small class="rc-text-muted">${escapeHtml(deviceId || 'Unknown ID')}</small>
                         </div>
                         <div class="rc-text-sm rc-text-secondary" title="${customPrice ? 'Custom price set for this device' : 'Price from product'}">
-                            €${priceLabel}${priceNote}
+                            ${appCurrencySymbol}${priceLabel}${priceNote}
                         </div>
                     </div>
                 `;
@@ -828,7 +830,7 @@
                             </select>
                         </div>
                         <div class="rc-form-group">
-                            <label class="rc-label">Revenue (€)</label>
+                            <label class="rc-label">Revenue (${appCurrencySymbol})</label>
                             <input type="number" class="rc-input" name="revenue" value="${job.revenue || ''}" step="0.01" min="0">
                         </div>
                         <div class="rc-form-group">
@@ -846,7 +848,7 @@
                         <div class="rc-form-group">
                             <label class="rc-label">Discount Type</label>
                             <select class="rc-select" name="discount_type">
-                                <option value="amount" ${job.discount_type === 'amount' ? 'selected' : ''}>Amount (€)</option>
+                                <option value="amount" ${job.discount_type === 'amount' ? 'selected' : ''}>Amount (${appCurrencySymbol})</option>
                                 <option value="percent" ${job.discount_type === 'percent' ? 'selected' : ''}>Percentage (%)</option>
                             </select>
                         </div>
@@ -2770,7 +2772,7 @@
                                        step="0.01"
                                        onchange="updateDevicePrice(${jobID}, '${deviceID}', this.value)"
                                        placeholder="${price.toFixed(2)}">
-                                <span class="rc-text-xs">€/day</span>
+                                <span class="rc-text-xs">${appCurrencySymbol}/day</span>
                                 <button type="button" onclick="removeDeviceFromEditJob(${jobID}, '${deviceID}')"
                                         class="rc-btn rc-btn-outline rc-btn-sm"
                                         style="padding: 2px 6px;"
@@ -3050,7 +3052,7 @@
                                        step="0.01"
                                        onchange="updateDevicePrice(${jobID}, '${device.device?.deviceID}', this.value)"
                                        placeholder="0.00">
-                                <span class="rc-text-sm">€</span>
+                                <span class="rc-text-sm">${appCurrencySymbol}</span>
                             </div>
                         </div>
                     `;
@@ -3129,7 +3131,7 @@
                     const revenueCell = jobRow.querySelector('td:nth-child(8)'); // Revenue column
                     if (revenueCell) {
                         const newRevenue = data.finalRevenue || data.revenue || 0;
-                        revenueCell.innerHTML = `<span class="rc-text-mono">€${newRevenue.toFixed(2)}</span>`;
+                        revenueCell.innerHTML = `<span class="rc-text-mono">${appCurrencySymbol}${newRevenue.toFixed(2)}</span>`;
                     }
                 }
                 
@@ -3137,9 +3139,9 @@
                 const currentModalJobID = document.getElementById('jobDetailsModal').getAttribute('data-current-job-id');
                 if (currentModalJobID == jobID) {
                     const modalRevenue = document.querySelector('#jobDetailsContent .rc-text-lg');
-                    if (modalRevenue && modalRevenue.textContent.startsWith('€')) {
+                    if (modalRevenue && modalRevenue.textContent.startsWith(appCurrencySymbol)) {
                         const newRevenue = data.finalRevenue || data.revenue || 0;
-                        modalRevenue.textContent = `€${newRevenue.toFixed(2)}`;
+                        modalRevenue.textContent = `${appCurrencySymbol}${newRevenue.toFixed(2)}`;
                     }
                 }
             })

--- a/web/templates/profile_settings_standalone.html
+++ b/web/templates/profile_settings_standalone.html
@@ -591,7 +591,7 @@
                                         <i class="bi bi-key" style="color: var(--accent-red);"></i>
                                         <div>
                                             <div style="font-weight: 500; color: var(--text-primary);">{{.Name}}</div>
-                                            <div style="font-size: 0.75rem; color: var(--text-muted);">Added {{.CreatedAt.Format "Jan 2, 2006"}}</div>
+                                            <div style="font-size: 0.75rem; color: var(--text-muted);">Added {{.CreatedAt.Format "2006-01-02"}}</div>
                                         </div>
                                     </div>
                                     <button type="button" class="modern-btn modern-btn-secondary" style="padding: var(--space-2) var(--space-3);" onclick="deletePasskey({{.PasskeyID}})">

--- a/web/templates/profile_settings_standalone_backup.html
+++ b/web/templates/profile_settings_standalone_backup.html
@@ -864,7 +864,7 @@
                 <div>
                     <div class="rc-text-sm rc-font-medium">${name}</div>
                     <div class="rc-text-xs rc-text-muted">
-                        Created: ${new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+                        Created: ${new Date().toISOString().slice(0, 10)}
                     </div>
                 </div>
             </div>

--- a/web/templates/profile_settings_standalone_backup.html
+++ b/web/templates/profile_settings_standalone_backup.html
@@ -854,6 +854,11 @@
         if (noPasskeysMessage) {
             noPasskeysMessage.remove();
         }
+
+        const today = new Date();
+        const todayStr = today.getFullYear() + '-' +
+            String(today.getMonth() + 1).padStart(2, '0') + '-' +
+            String(today.getDate()).padStart(2, '0');
         
         const passkeyElement = document.createElement('div');
         passkeyElement.className = 'rc-flex rc-flex-between rc-flex-center rc-p-sm rc-border rc-rounded rc-mb-sm';
@@ -864,7 +869,7 @@
                 <div>
                     <div class="rc-text-sm rc-font-medium">${name}</div>
                     <div class="rc-text-xs rc-text-muted">
-                        Created: ${(() => { const n = new Date(); const y = n.getFullYear(); const m = String(n.getMonth() + 1).padStart(2, '0'); const d = String(n.getDate()).padStart(2, '0'); return `${y}-${m}-${d}`; })()}
+                        Created: ${todayStr}
                     </div>
                 </div>
             </div>

--- a/web/templates/profile_settings_standalone_backup.html
+++ b/web/templates/profile_settings_standalone_backup.html
@@ -864,7 +864,7 @@
                 <div>
                     <div class="rc-text-sm rc-font-medium">${name}</div>
                     <div class="rc-text-xs rc-text-muted">
-                        Created: ${new Date().toISOString().slice(0, 10)}
+                        Created: ${(() => { const n = new Date(); const y = n.getFullYear(); const m = String(n.getMonth() + 1).padStart(2, '0'); const d = String(n.getDate()).padStart(2, '0'); return `${y}-${m}-${d}`; })()}
                     </div>
                 </div>
             </div>

--- a/web/templates/profile_settings_standalone_backup.html
+++ b/web/templates/profile_settings_standalone_backup.html
@@ -210,8 +210,8 @@
                                             <div>
                                                 <div class="rc-text-sm rc-font-medium">{{.Name}}</div>
                                                 <div class="rc-text-xs rc-text-muted">
-                                                    Created: {{.CreatedAt.Format "Jan 2, 2006"}}
-                                                    {{if .LastUsed}} • Last used: {{.LastUsed.Format "Jan 2, 2006"}}{{end}}
+                                                    Created: {{.CreatedAt.Format "2006-01-02"}}
+                                                    {{if .LastUsed}} • Last used: {{.LastUsed.Format "2006-01-02"}}{{end}}
                                                 </div>
                                             </div>
                                         </div>

--- a/web/templates/security_audit.html
+++ b/web/templates/security_audit.html
@@ -1065,7 +1065,21 @@ function saveFilterPreset() {
 
 // Utility functions
 function formatTimestamp(timestamp) {
-    return new Date(timestamp).toISOString().slice(0, 16).replace('T', ' ');
+    if (!timestamp) {
+        return '-';
+    }
+
+    const date = new Date(timestamp);
+    if (isNaN(date.getTime())) {
+        return '-';
+    }
+
+    const y = date.getFullYear();
+    const mo = String(date.getMonth() + 1).padStart(2, '0');
+    const d = String(date.getDate()).padStart(2, '0');
+    const h = String(date.getHours()).padStart(2, '0');
+    const min = String(date.getMinutes()).padStart(2, '0');
+    return `${y}-${mo}-${d} ${h}:${min}`;
 }
 
 function escapeHtml(text) {

--- a/web/templates/security_audit.html
+++ b/web/templates/security_audit.html
@@ -1065,7 +1065,7 @@ function saveFilterPreset() {
 
 // Utility functions
 function formatTimestamp(timestamp) {
-    return new Date(timestamp).toLocaleString();
+    return new Date(timestamp).toISOString().slice(0, 16).replace('T', ' ');
 }
 
 function escapeHtml(text) {

--- a/web/templates/signature_form.html
+++ b/web/templates/signature_form.html
@@ -174,7 +174,7 @@
                         
                         <div class="mb-3">
                             <small class="text-muted d-block">Uploaded</small>
-                            <span>{{.document.UploadedAt.Format "Jan 2, 2006 15:04"}}</span>
+                            <span>{{.document.UploadedAt.Format "2006-01-02 15:04"}}</span>
                         </div>
                         
                         {{if .document.Description}}
@@ -209,7 +209,7 @@
                             <div>
                                 <div class="fw-bold">{{.SignerName}}</div>
                                 <small class="text-muted">{{.SignerRole}}</small>
-                                <div class="small text-muted">{{.SignedAt.Format "Jan 2, 2006 15:04"}}</div>
+                                <div class="small text-muted">{{.SignedAt.Format "2006-01-02 15:04"}}</div>
                                 {{if .IsVerified}}
                                 <span class="badge bg-success small">Verified</span>
                                 {{else}}

--- a/web/templates/transaction_detail.html
+++ b/web/templates/transaction_detail.html
@@ -127,7 +127,7 @@
                             <div class="col-md-6 mb-3">
                                 <label class="form-label fw-bold">Transaction Date</label>
                                 <div class="form-control-plaintext">
-                                    {{.transaction.TransactionDate.Format "January 2, 2006 at 3:04 PM"}}
+                                    {{.transaction.TransactionDate.Format "2006-01-02 15:04"}}
                                 </div>
                             </div>
 
@@ -135,7 +135,7 @@
                                 <label class="form-label fw-bold">Due Date</label>
                                 <div class="form-control-plaintext">
                                     {{if .transaction.DueDate}}
-                                        {{.transaction.DueDate.Format "January 2, 2006"}}
+                                        {{.transaction.DueDate.Format "2006-01-02"}}
                                         {{if .transaction.DueDate.Before now}}
                                             <span class="badge bg-danger ms-2">Overdue</span>
                                         {{end}}
@@ -225,7 +225,7 @@
                             <div class="col-md-6 mb-3">
                                 <label class="form-label fw-bold">Last Updated</label>
                                 <div class="form-control-plaintext">
-                                    {{.transaction.UpdatedAt.Format "January 2, 2006 at 3:04 PM"}}
+                                    {{.transaction.UpdatedAt.Format "2006-01-02 15:04"}}
                                 </div>
                             </div>
                         </div>
@@ -246,7 +246,7 @@
                                 <div class="timeline-content">
                                     <h6 class="timeline-title">Transaction Created</h6>
                                     <p class="timeline-text">Transaction was created with status: pending</p>
-                                    <small class="text-muted">{{.transaction.CreatedAt.Format "January 2, 2006 at 3:04 PM"}}</small>
+                                    <small class="text-muted">{{.transaction.CreatedAt.Format "2006-01-02 15:04"}}</small>
                                 </div>
                             </div>
                             {{if ne .transaction.Status "pending"}}
@@ -255,7 +255,7 @@
                                 <div class="timeline-content">
                                     <h6 class="timeline-title">Status Updated</h6>
                                     <p class="timeline-text">Transaction status changed to: {{.transaction.Status}}</p>
-                                    <small class="text-muted">{{.transaction.UpdatedAt.Format "January 2, 2006 at 3:04 PM"}}</small>
+                                    <small class="text-muted">{{.transaction.UpdatedAt.Format "2006-01-02 15:04"}}</small>
                                 </div>
                             </div>
                             {{end}}

--- a/web/templates/user_detail.html
+++ b/web/templates/user_detail.html
@@ -245,17 +245,17 @@
                                 </div>
                                 <div style="display: flex; justify-content: space-between; align-items: center; padding: var(--space-sm) 0; border-bottom: 1px solid var(--surface-3);">
                                     <span style="font-weight: 500; color: var(--text-secondary);">Created:</span>
-                                    <span style="font-family: var(--font-mono); color: var(--text-primary); font-size: 0.875rem;">{{.viewUser.CreatedAt.Format "Jan 2, 2006 15:04"}}</span>
+                                    <span style="font-family: var(--font-mono); color: var(--text-primary); font-size: 0.875rem;">{{.viewUser.CreatedAt.Format "2006-01-02 15:04"}}</span>
                                 </div>
                                 <div style="display: flex; justify-content: space-between; align-items: center; padding: var(--space-sm) 0; border-bottom: 1px solid var(--surface-3);">
                                     <span style="font-weight: 500; color: var(--text-secondary);">Updated:</span>
-                                    <span style="font-family: var(--font-mono); color: var(--text-primary); font-size: 0.875rem;">{{.viewUser.UpdatedAt.Format "Jan 2, 2006 15:04"}}</span>
+                                    <span style="font-family: var(--font-mono); color: var(--text-primary); font-size: 0.875rem;">{{.viewUser.UpdatedAt.Format "2006-01-02 15:04"}}</span>
                                 </div>
                                 <div style="display: flex; justify-content: space-between; align-items: center; padding: var(--space-sm) 0;">
                                     <span style="font-weight: 500; color: var(--text-secondary);">Last Login:</span>
                                     <span style="font-family: var(--font-mono); color: var(--text-primary); font-size: 0.875rem;">
                                         {{if .viewUser.LastLogin}}
-                                            {{.viewUser.LastLogin.Format "Jan 2, 2006 15:04"}}
+                                            {{.viewUser.LastLogin.Format "2006-01-02 15:04"}}
                                         {{else}}
                                             <span style="color: var(--text-muted); font-style: italic;">Never logged in</span>
                                         {{end}}

--- a/web/templates/users_list.html
+++ b/web/templates/users_list.html
@@ -1047,6 +1047,17 @@ class UserManagement {
     }
 }
 
+// Date helpers: format as local YYYY-MM-DD (date-only)
+function toLocalDateStr(d) {
+    if (!d) return '';
+    const dt = new Date(d);
+    if (isNaN(dt.getTime())) return '';
+    const y = dt.getFullYear();
+    const m = String(dt.getMonth() + 1).padStart(2, '0');
+    const day = String(dt.getDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+}
+
 // Modal functionality
 function showModal(title, message, confirmCallback) {
     const modal = document.getElementById('confirmModal');
@@ -1367,16 +1378,16 @@ function openViewUserModal(userId) {
                     <div style="display: flex; flex-direction: column; gap: var(--space-sm);">
                         <div style="display: flex; justify-content: space-between; padding: var(--space-xs) 0; border-bottom: 1px solid var(--surface-3);">
                             <span style="color: var(--text-secondary);">Created:</span>
-                            <span style="font-family: var(--font-mono); color: var(--text-primary); font-size: 0.875rem;">${new Date(user.createdAt).toISOString().slice(0, 10)}</span>
+                            <span style="font-family: var(--font-mono); color: var(--text-primary); font-size: 0.875rem;">${toLocalDateStr(user.createdAt)}</span>
                         </div>
                         <div style="display: flex; justify-content: space-between; padding: var(--space-xs) 0; border-bottom: 1px solid var(--surface-3);">
                             <span style="color: var(--text-secondary);">Updated:</span>
-                            <span style="font-family: var(--font-mono); color: var(--text-primary); font-size: 0.875rem;">${new Date(user.updatedAt).toISOString().slice(0, 10)}</span>
+                            <span style="font-family: var(--font-mono); color: var(--text-primary); font-size: 0.875rem;">${toLocalDateStr(user.updatedAt)}</span>
                         </div>
                         <div style="display: flex; justify-content: space-between; padding: var(--space-xs) 0;">
                             <span style="color: var(--text-secondary);">Last Login:</span>
                             <span style="font-family: var(--font-mono); color: var(--text-primary); font-size: 0.875rem;">
-                                ${user.lastLogin ? new Date(user.lastLogin).toISOString().slice(0, 10) : '<span style="color: var(--text-muted); font-style: italic;">Never</span>'}
+                                ${user.lastLogin ? toLocalDateStr(user.lastLogin) : '<span style="color: var(--text-muted); font-style: italic;">Never</span>'}
                             </span>
                         </div>
                     </div>
@@ -1536,7 +1547,7 @@ function renderCurrentRoles() {
     container.innerHTML = userRoles.map(userRole => {
         const role = userRole.role || userRole;
         const expiryText = userRole.expiresAt ? 
-            `<span class="role-expiry">Expires: ${new Date(userRole.expiresAt).toISOString().slice(0, 10)}</span>` : 
+            `<span class="role-expiry">Expires: ${toLocalDateStr(userRole.expiresAt)}</span>` : 
             '<span class="role-expiry">No expiry</span>';
         
         return `

--- a/web/templates/users_list.html
+++ b/web/templates/users_list.html
@@ -1367,16 +1367,16 @@ function openViewUserModal(userId) {
                     <div style="display: flex; flex-direction: column; gap: var(--space-sm);">
                         <div style="display: flex; justify-content: space-between; padding: var(--space-xs) 0; border-bottom: 1px solid var(--surface-3);">
                             <span style="color: var(--text-secondary);">Created:</span>
-                            <span style="font-family: var(--font-mono); color: var(--text-primary); font-size: 0.875rem;">${new Date(user.createdAt).toLocaleDateString()}</span>
+                            <span style="font-family: var(--font-mono); color: var(--text-primary); font-size: 0.875rem;">${new Date(user.createdAt).toISOString().slice(0, 10)}</span>
                         </div>
                         <div style="display: flex; justify-content: space-between; padding: var(--space-xs) 0; border-bottom: 1px solid var(--surface-3);">
                             <span style="color: var(--text-secondary);">Updated:</span>
-                            <span style="font-family: var(--font-mono); color: var(--text-primary); font-size: 0.875rem;">${new Date(user.updatedAt).toLocaleDateString()}</span>
+                            <span style="font-family: var(--font-mono); color: var(--text-primary); font-size: 0.875rem;">${new Date(user.updatedAt).toISOString().slice(0, 10)}</span>
                         </div>
                         <div style="display: flex; justify-content: space-between; padding: var(--space-xs) 0;">
                             <span style="color: var(--text-secondary);">Last Login:</span>
                             <span style="font-family: var(--font-mono); color: var(--text-primary); font-size: 0.875rem;">
-                                ${user.lastLogin ? new Date(user.lastLogin).toLocaleDateString() : '<span style="color: var(--text-muted); font-style: italic;">Never</span>'}
+                                ${user.lastLogin ? new Date(user.lastLogin).toISOString().slice(0, 10) : '<span style="color: var(--text-muted); font-style: italic;">Never</span>'}
                             </span>
                         </div>
                     </div>
@@ -1536,7 +1536,7 @@ function renderCurrentRoles() {
     container.innerHTML = userRoles.map(userRole => {
         const role = userRole.role || userRole;
         const expiryText = userRole.expiresAt ? 
-            `<span class="role-expiry">Expires: ${new Date(userRole.expiresAt).toLocaleDateString()}</span>` : 
+            `<span class="role-expiry">Expires: ${new Date(userRole.expiresAt).toISOString().slice(0, 10)}</span>` : 
             '<span class="role-expiry">No expiry</span>';
         
         return `

--- a/web/templates/users_list.html
+++ b/web/templates/users_list.html
@@ -729,12 +729,12 @@
                             </div>
                             <div class="user-meta-item">
                                 <i class="bi bi-calendar-plus"></i>
-                                <span>Created {{.CreatedAt.Format "Jan 2, 2006"}}</span>
+                                <span>Created {{.CreatedAt.Format "2006-01-02"}}</span>
                             </div>
                             <div class="user-meta-item">
                                 <i class="bi bi-clock"></i>
                                 {{if .LastLogin}}
-                                    <span>Last login {{.LastLogin.Format "Jan 2, 2006"}}</span>
+                                    <span>Last login {{.LastLogin.Format "2006-01-02"}}</span>
                                 {{else}}
                                     <span>Never logged in</span>
                                 {{end}}


### PR DESCRIPTION
Multiple regressions introduced when adding `scope`/`id` to `app_settings`: migration failures on live DBs, wrong-scope row reads, concurrent upsert races, `NaN:NaN` in history modal, and XSS via admin-settable currency symbol.

## Migration 040 (`app_settings` schema)

- **`scope` column**: Added without `NOT NULL`, then explicit `UPDATE ... WHERE scope IS NULL`, then `SET DEFAULT`/`SET NOT NULL` — safe on partially-migrated DBs where the column already exists as nullable
- **`id` backfill**: Sequence created, existing rows backfilled, then `setval(MAX(id))` to prevent future duplicate-key collisions
- **Step 8 (unique constraint)**: Added `DROP INDEX IF EXISTS idx_app_settings_scope_key` alongside `DROP CONSTRAINT IF EXISTS` — GORM AutoMigrate creates an index, not a named constraint, so `ADD CONSTRAINT` would fail without this
- **Down migration**: Drops `scope` before restoring the key-only PK to avoid duplicate-key violations across scopes

## `AppSetting` model

Added `not null` struct tags to `Scope` and `Key` so `AutoMigrate` produces a schema matching production.

## Scope-consistent DB queries (`TwentyService`)

All `app_settings` reads/writes now include `scope = 'global'`: `GetConfig`, `storedID`, `storeID`, `reverseCustomerIDLookup`. All upserts use `ON CONFLICT (scope, key)`.

## Atomic upsert (`SettingsService`)

Replaced read-then-create transaction (race-prone under concurrency) with a single statement:

```go
s.db.Clauses(clause.OnConflict{
    Columns:   []clause.Column{{Name: "scope"}, {Name: "key"}},
    DoUpdates: clause.Assignments(map[string]interface{}{"value": jsonValue, "updated_at": time.Now()}),
}).Create(&setting)
```

`readCurrencyFromDB` tries `global` then `warehousecore` scope, parses `{"symbol":"..."}` JSON, falls back to raw value for legacy rows, and returns `(symbol, cacheable=false)` on transient errors so the caller preserves the stale cache.

## Frontend

- **Currency XSS**: `appCurrencySymbol` pre-escaped into `appCurrencySymbolHtml` at declaration; all `innerHTML` template literals use the escaped variant
- **Local date formatting**: Replaced all `toISOString()` display calls with local-time helpers (`toLocalDateStr`/`toLocalDateTimeStr`) producing `YYYY-MM-DD` / `YYYY-MM-DD HH:MM` across `jobs.html`, `job_detail.html`, `security_audit.html`, `users_list.html`, `security-roles.js`, and `profile_settings_standalone_backup.html`
- **`formatDate`**: Resilient to invalid/empty inputs; passes through `YYYY-MM-DD HH:MM:SS` strings (PDF pool endpoint) without UTC conversion
- **History modal `NaN:NaN`**: Guards `formattedDate`/`formattedTime` with `isNaN(changeDate.getTime())`

## Tests

- All `AppSetting` fixtures updated with `Scope: "global"`; queries filter by `(scope, key)`
- New tests for `readCurrencyFromDB`: JSON parsing, `warehousecore` fallback, global precedence, JSON parse after cache expiry